### PR TITLE
feat: add --ignore flag to filter files/functions

### DIFF
--- a/oracletrace/cli.py
+++ b/oracletrace/cli.py
@@ -14,6 +14,7 @@ def main():
     parser.add_argument("target", help="Python script to trace")
     parser.add_argument("--json", help="Export trace result to JSON file")
     parser.add_argument("--compare", help="Compare against previous trace JSON")
+    parser.add_argument("--ignore", help="Regex pattern to filter files/functions (e.g., 'test_.*' or '.*migrations.*')")
     args = parser.parse_args()
 
     target = args.target
@@ -29,7 +30,7 @@ def main():
     sys.path.insert(0, target_dir)
 
     # Start tracing, run the script, then stop
-    tracer = Tracer(root)
+    tracer = Tracer(root, ignore_pattern=args.ignore)
     tracer.start()
     try:
         runpy.run_path(target, run_name="__main__")

--- a/oracletrace/tracer.py
+++ b/oracletrace/tracer.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import re
 import time
 from collections import defaultdict
 from rich.tree import Tree
@@ -8,7 +9,7 @@ from rich import print
 
 
 class Tracer:
-    def __init__(self, root_dir):
+    def __init__(self, root_dir, ignore_pattern=None):
         self._root_path = os.path.abspath(root_dir)
         self._call_stack = []
         self._func_calls = defaultdict(int)
@@ -16,6 +17,7 @@ class Tracer:
         self._call_map = defaultdict(lambda: defaultdict(int))
         self._original_profile_func = None
         self._enabled = False
+        self._ignore_pattern = re.compile(ignore_pattern) if ignore_pattern else None
 
     def start(self):
         # Start Tracer
@@ -48,7 +50,13 @@ class Tracer:
             return None
         # Create a relative path key for readability
         rel_path = os.path.relpath(filename, self._root_path)
-        return f"{rel_path}:{frame.f_code.co_name}"
+        key = f"{rel_path}:{frame.f_code.co_name}"
+        
+        # Apply ignore pattern if specified
+        if self._ignore_pattern and self._ignore_pattern.search(key):
+            return None
+        
+        return key
 
     def _trace(self, frame, event, arg):
         try:

--- a/test_app.py
+++ b/test_app.py
@@ -1,0 +1,29 @@
+import time
+
+def process_data():
+    """Main processing function"""
+    time.sleep(0.05)
+    calculate_results()
+
+def calculate_results():
+    """Calculation function"""
+    time.sleep(0.05)
+
+def test_function():
+    """Test function that should be filtered"""
+    time.sleep(0.03)
+
+def test_another():
+    """Another test function"""
+    time.sleep(0.02)
+
+def main():
+    for _ in range(2):
+        process_data()
+    
+    # These should be filtered when using --ignore "test_.*"
+    test_function()
+    test_another()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

This PR implements the `--ignore` flag feature requested in #5.

## Changes

- Added `--ignore` CLI argument that accepts regex patterns
- Updated `Tracer` class to accept and apply ignore patterns
- Pattern matches against the format `filename:function_name`
- Functions/files matching the pattern are excluded from trace output

## Examples

**Filter functions by name pattern:**
```bash
oracletrace my_app.py --ignore ".*:test_.*"
```

**Filter entire files:**
```bash
oracletrace my_app.py --ignore "test_.*\.py:.*"
```

**Filter migrations:**
```bash
oracletrace my_app.py --ignore ".*migrations.*"
```

## Testing

Tested with sample script to verify:
- ✅ Functions matching pattern are excluded
- ✅ Files matching pattern are excluded
- ✅ Non-matching functions still appear in output
- ✅ Works without the flag (backward compatible)

Fixes #5