### PR TITLE
feat: cli flag --only-regressions

### DIFF
--- a/docs/docs/cli-reference.md
+++ b/docs/docs/cli-reference.md
@@ -14,7 +14,7 @@ Complete command reference for OracleTrace.
 oracletrace <target> [--json OUTPUT.json] [--csv OUTPUT.csv] [--compare BASELINE.json]
 oracletrace <target> [--ignore REGEX [REGEX ...]]
 oracletrace <target> [--top NUMBER]
-oracletrace <target> [--compare BASELINE.json] [--fail-on-regression] [--threshold PERCENT]
+oracletrace <target> [--compare BASELINE.json] [--fail-on-regression] [--threshold PERCENT] [--only-regressions]
 ```
 
 ## Required argument
@@ -83,6 +83,18 @@ Default value: `5.0`
 
 ```bash
 oracletrace my_app.py --compare baseline.json --fail-on-regression --threshold 25
+```
+
+### `---only-regressions`
+
+Shows only the regressions in the diff output when comparing traces.
+
+Use with `--compare`.
+
+Default value: False
+
+```bash
+oracletrace my_app.py --compare baseline.json --only-regressions
 ```
 
 ### `--ignore`

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -75,6 +75,12 @@ Exit code behavior in this case:
 - `0` when no regression exceeds threshold
 - `2` when at least one regression exceeds threshold
 
+## Print only regressions
+
+```bash
+oracletrace my_script.py --compare baseline.json --only-regressions
+```
+
 ## Ignore noisy functions or files
 
 ```bash

--- a/oracletrace/cli.py
+++ b/oracletrace/cli.py
@@ -43,6 +43,11 @@ def main() -> int:
         default=5.0,
         help="Regression threshold percentage used with --fail-on-regression.",
     )
+    parser.add_argument(
+        "--only-regressions",
+        action="store_true",
+        help="Hide functions which didn't run slower than baseline. Use with --compare"
+    )
     args: Namespace = parser.parse_args()
 
     target: str = args.target
@@ -111,7 +116,7 @@ def main() -> int:
         with open(args.compare, "r", encoding="utf-8") as f:
             old_data: TracerData = TracerData.from_dict(json.load(f))
 
-        comparison_result = compare_traces(old_data, data, threshold=args.threshold)
+        comparison_result = compare_traces(old_data, data, threshold=args.threshold, show_only_regressions=args.only_regressions)
 
         if args.fail_on_regression and comparison_result.has_regression:
             print(

--- a/oracletrace/compare.py
+++ b/oracletrace/compare.py
@@ -15,7 +15,12 @@ class ComparisonData:
     regressions: List[RegressionData]
     has_regression: bool
 
-def compare_traces(old_data: TracerData, new_data: TracerData, threshold: float = 5.0) -> ComparisonData:
+def compare_traces(
+    old_data: TracerData,
+    new_data: TracerData,
+    threshold: float = 5.0,
+    show_only_regressions: bool = False
+) -> ComparisonData:
     old_funcs: Dict[str, FunctionData] = {f.name: f for f in old_data.functions}
     new_funcs: Dict[str, FunctionData] = {f.name: f for f in new_data.functions}
 
@@ -52,8 +57,9 @@ def compare_traces(old_data: TracerData, new_data: TracerData, threshold: float 
             f"{name}\n"
             f"    total_time: {old_time:.4f}s → {new_time:.4f}s "
             f"[{color}]({percent:+.2f}%)[/]\n"
-        )
-
+        ) if not show_only_regressions or diff > 0.0 else ...
+        
+        
         if percent > threshold:
             regressions.append(
                 RegressionData(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,33 @@ assert str(REPO_ROOT / "oracletrace") in str(Path(cli.__file__).resolve())
 def trace_data() -> TracerData:
     return TracerData(
         metadata = TracerMetadata(
-            total_execution_time = 3.0,
+            total_execution_time = 5.033,
+            total_functions = 2,
+            root_path = str(REPO_ROOT) 
+        ),
+        functions = [
+            FunctionData(
+                name = "foo",
+                total_time = 3.033,
+                call_count = 3,
+                avg_time = 1.011,
+                callees=[]
+            ),
+            FunctionData(
+                name = "bar",
+                total_time = 2.0,
+                call_count = 2,
+                avg_time = 1.0,
+                callees=[]
+            )
+        ]
+    )
+
+@pytest.fixture
+def baseline_trace_data() -> TracerData:
+    return TracerData(
+        metadata = TracerMetadata(
+            total_execution_time = 3.5,
             total_functions = 2,
             root_path = str(REPO_ROOT) 
         ),
@@ -148,7 +174,7 @@ def test_main_runs_trace_and_exports_json_and_csv(monkeypatch, tmp_path, trace_d
 
     csv_text = csv_output.read_text(encoding="utf-8")
     assert "function,total_time,calls,avg_time" in csv_text
-    assert "foo,1.5,3,0.5" in csv_text
+    assert "foo,3.033,3,1.011" in csv_text
     assert "bar,2.0,2,1.0" in csv_text
 
     assert sys.path[0] == str(target.parent.resolve())
@@ -203,8 +229,8 @@ def test_main_fails_with_exit_2_on_regression(monkeypatch, tmp_path, empty_trace
 
     compare_calls = []
 
-    def fake_compare_traces(old_data, new_data, threshold):
-        compare_calls.append((old_data, new_data, threshold))
+    def fake_compare_traces(old_data, new_data, threshold, show_only_regressions):
+        compare_calls.append((old_data, new_data, threshold, show_only_regressions))
         return ComparisonData(regressions=[], has_regression=True)
 
     monkeypatch.setattr(cli, "compare_traces", fake_compare_traces)
@@ -236,7 +262,14 @@ def test_main_returns_0_when_no_regression(monkeypatch, tmp_path, trace_data):
 
     monkeypatch.setattr(cli, "Tracer", lambda root, ignore_patterns: FakeTracer(root, ignore_patterns, trace_data))
     monkeypatch.setattr(cli.runpy, "run_path", lambda *args, **kwargs: None)
-    monkeypatch.setattr(cli, "compare_traces", lambda old_data, new_data, threshold: ComparisonData(regressions=[], has_regression=False))
+    monkeypatch.setattr(
+        cli,
+        "compare_traces",
+        lambda old_data, new_data, threshold, show_only_regressions: ComparisonData(
+            regressions=[],
+            has_regression=False
+        )
+    )
 
     exit_code = _run_cli(
         monkeypatch,
@@ -250,3 +283,29 @@ def test_main_returns_0_when_no_regression(monkeypatch, tmp_path, trace_data):
     )
 
     assert exit_code == 0
+
+def test_main_shows_only_regressions(monkeypatch, tmp_path, trace_data, baseline_trace_data, capsys):
+    target = tmp_path / "target.py"
+    target.write_text("print('hello')\n", encoding="utf-8")
+    compare_file = tmp_path / "baseline.json"
+    compare_file.write_text(json.dumps(asdict(baseline_trace_data)), encoding="utf-8")
+    
+    monkeypatch.setattr(cli, "Tracer", lambda root, ignore_patterns: FakeTracer(root, ignore_patterns, trace_data))
+    monkeypatch.setattr(cli.runpy, "run_path", lambda *args, **kwargs: None)
+
+    exit_code = _run_cli(
+        monkeypatch,
+        [
+            "oracletrace",
+            str(target),
+            "--compare",
+            str(compare_file),
+            "--only-regressions",
+        ],
+    )
+
+    captured = capsys.readouterr()
+    assert f"{trace_data.functions[0].name}\n" in captured.out
+    assert f"    total_time: {baseline_trace_data.functions[0].total_time:.4f}s → {trace_data.functions[0].total_time:.4f}s" in captured.out
+    assert f"(+{102.2:.2f}%)\n" in captured.out
+    assert f"{trace_data.functions[1].name}\n" not in captured.out


### PR DESCRIPTION
## Summary

Implements cli flag `--only-regression`

## Related Issue

Closes #29 


## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [X] Documentation update
- [X] CLI behavior change

## What Changed

List the key changes in a few bullets.

- Add a cli flag that allows to only print regressions in diff output

## Validation

- Ran tests
- Ran cli smoke checks
- Checked docs build

## Checklist

- [X] The code follows style conventions.
- [X] I added unit tests for the new functionality.
- [X] CI (GitHub Actions) is green.
- [ ] I updated documentation/README when needed.

## Before/After Output (if applicable)

```bash
$ oracletrace sample.py  --compare old.json --only-regressions

Summary:
Total execution time: 0.6026s
                         Top functions by Total Time                          
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┓
┃ Function                    ┃ Total Time (s) ┃ Calls ┃ Avg. Time/Call (ms) ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━┩
│ sample.py:<module>          │         0.6014 │     1 │             601.392 │
│ sample.py:main              │         0.6014 │     1 │             601.371 │
│ sample.py:process_data      │         0.6012 │     2 │             300.622 │
│ sample.py:calculate_results │         0.4002 │     2 │             200.121 │
└─────────────────────────────┴────────────────┴───────┴─────────────────────┘

Logic Flow:
<module>
├── sample.py:<module> (1x, 0.6014s)
│   └── sample.py:main (1x, 0.6014s)
│       └── sample.py:process_data (2x, 0.6012s)
│           └── sample.py:calculate_results (2x, 0.4002s)
└── oracletrace/tracer.py:Tracer.stop (1x, 0.0000s)

Comparison Results:

sample.py:<module>
    total_time: 0.6010s → 0.6014s (+0.06%)

sample.py:main
    total_time: 0.6010s → 0.6014s (+0.06%)

sample.py:process_data
    total_time: 0.6009s → 0.6012s (+0.07%)
```


This is a possibility, not really sure how to handle it when there's no regression to print. Is it ok to leave the Comparison result section empty?

```bash
$ oracletrace sample.py --compare old.json --only-regressions

Summary:
Total execution time: 0.6025s
                         Top functions by Total Time                          
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┓
┃ Function                    ┃ Total Time (s) ┃ Calls ┃ Avg. Time/Call (ms) ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━┩
│ sample.py:<module>          │         0.6010 │     1 │             600.996 │
│ sample.py:main              │         0.6010 │     1 │             600.973 │
│ sample.py:process_data      │         0.6008 │     2 │             300.419 │
│ sample.py:calculate_results │         0.4003 │     2 │             200.139 │
└─────────────────────────────┴────────────────┴───────┴─────────────────────┘

Logic Flow:
<module>
├── sample.py:<module> (1x, 0.6010s)
│   └── sample.py:main (1x, 0.6010s)
│       └── sample.py:process_data (2x, 0.6008s)
│           └── sample.py:calculate_results (2x, 0.4003s)
└── oracletrace/tracer.py:Tracer.stop (1x, 0.0000s)

Comparison Results:

```