### PR TITLE
fix: validate --top as positive integer and send errors to stderr

### DIFF
--- a/oracletrace/cli.py
+++ b/oracletrace/cli.py
@@ -29,7 +29,8 @@ def main() -> int:
     )
     parser.add_argument(
         "--top",
-        metavar="NUMBER", 
+        metavar="NUMBER",
+        type=int,
         help="Limits the number of functions shown in the summary table"
     )
     parser.add_argument(
@@ -52,8 +53,12 @@ def main() -> int:
 
     target: str = args.target
 
+    if args.top is not None and args.top < 1:
+        print(f"--top must be a positive integer, got: {args.top}", file=sys.stderr)
+        return 1
+
     if not os.path.exists(target):
-        print(f"Target not found: {target}")
+        print(f"Target not found: {target}", file=sys.stderr)
         return 1
 
     target = os.path.abspath(target)
@@ -68,7 +73,7 @@ def main() -> int:
         try:
             ignore_patterns.append(re.compile(pattern))
         except re.error as e:
-            print(f"Regex error: {pattern} -> {e}")
+            print(f"Regex error: {pattern} -> {e}", file=sys.stderr)
             return 1
 
     # Start tracing, run the script, then stop
@@ -87,8 +92,8 @@ def main() -> int:
             json.dump(asdict(data), f, indent=4)
 
     # Display the analysis
-    if args.top:
-        tracer.show_results(int(args.top[0]))
+    if args.top is not None:
+        tracer.show_results(args.top)
     else:
         tracer.show_results(None)
 
@@ -110,7 +115,7 @@ def main() -> int:
     # Compare jsons
     if args.compare:
         if not os.path.exists(args.compare):
-            print(f"Compare file not found: {args.compare}")
+            print(f"Compare file not found: {args.compare}", file=sys.stderr)
             return 1
 
         with open(args.compare, "r", encoding="utf-8") as f:
@@ -120,7 +125,8 @@ def main() -> int:
 
         if args.fail_on_regression and comparison_result.has_regression:
             print(
-            f"Build failed: performance regression above {args.threshold:.2f}% detected."
+                f"Build failed: performance regression above {args.threshold:.2f}% detected.",
+                file=sys.stderr,
             )
             return 2
         

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -111,7 +111,7 @@ def test_main_returns_1_when_target_not_found(monkeypatch, capsys):
 
     captured = capsys.readouterr()
     assert exit_code == 1
-    assert "Target not found: missing_script.py" in captured.out
+    assert "Target not found: missing_script.py" in captured.err
 
 
 def test_main_returns_1_when_ignore_regex_is_invalid(monkeypatch, tmp_path, capsys):
@@ -122,7 +122,7 @@ def test_main_returns_1_when_ignore_regex_is_invalid(monkeypatch, tmp_path, caps
 
     captured = capsys.readouterr()
     assert exit_code == 1
-    assert "Regex error: [" in captured.out
+    assert "Regex error: [" in captured.err
 
 
 def test_main_runs_trace_and_exports_json_and_csv(monkeypatch, tmp_path, trace_data):
@@ -201,6 +201,59 @@ def test_main_passes_top_value_to_show_results(monkeypatch, tmp_path, trace_data
     assert fake_tracer.show_results_calls == [5]
 
 
+def test_main_passes_multidigit_top_value(monkeypatch, tmp_path, trace_data):
+    target = tmp_path / "target.py"
+    target.write_text("print('hello')\n", encoding="utf-8")
+
+    fake_tracer_holder = {}
+
+    def tracer_factory(root, ignore_patterns):
+        fake = FakeTracer(root, ignore_patterns, trace_data)
+        fake_tracer_holder["instance"] = fake
+        return fake
+
+    monkeypatch.setattr(cli, "Tracer", tracer_factory)
+    monkeypatch.setattr(cli.runpy, "run_path", lambda *args, **kwargs: None)
+
+    exit_code = _run_cli(monkeypatch, ["oracletrace", str(target), "--top", "10"])
+
+    fake_tracer = fake_tracer_holder["instance"]
+    assert exit_code == 0
+    assert fake_tracer.show_results_calls == [10]
+
+
+def test_main_rejects_zero_top(monkeypatch, tmp_path, capsys):
+    target = tmp_path / "target.py"
+    target.write_text("print('hello')\n", encoding="utf-8")
+
+    exit_code = _run_cli(monkeypatch, ["oracletrace", str(target), "--top", "0"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "--top must be a positive integer" in captured.err
+
+
+def test_main_rejects_negative_top(monkeypatch, tmp_path, capsys):
+    target = tmp_path / "target.py"
+    target.write_text("print('hello')\n", encoding="utf-8")
+
+    exit_code = _run_cli(monkeypatch, ["oracletrace", str(target), "--top", "-5"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "--top must be a positive integer" in captured.err
+
+
+def test_main_rejects_non_integer_top(monkeypatch, tmp_path):
+    target = tmp_path / "target.py"
+    target.write_text("print('hello')\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc_info:
+        _run_cli(monkeypatch, ["oracletrace", str(target), "--top", "foo"])
+
+    assert exc_info.value.code == 2
+
+
 def test_main_returns_1_when_compare_file_not_found(monkeypatch, tmp_path, trace_data, capsys):
     target = tmp_path / "target.py"
     target.write_text("print('hello')\n", encoding="utf-8")
@@ -215,7 +268,7 @@ def test_main_returns_1_when_compare_file_not_found(monkeypatch, tmp_path, trace
 
     captured = capsys.readouterr()
     assert exit_code == 1
-    assert "Compare file not found:" in captured.out
+    assert "Compare file not found:" in captured.err
 
 
 def test_main_fails_with_exit_2_on_regression(monkeypatch, tmp_path, empty_trace_data, capsys):
@@ -250,7 +303,7 @@ def test_main_fails_with_exit_2_on_regression(monkeypatch, tmp_path, empty_trace
 
     captured = capsys.readouterr()
     assert exit_code == 2
-    assert "Build failed: performance regression above 7.50% detected." in captured.out
+    assert "Build failed: performance regression above 7.50% detected." in captured.err
     assert compare_calls[0][2] == 7.5
 
 


### PR DESCRIPTION
## Summary

Fixes #41 — `--top` integer parsing/validation bug. Also addresses #42 (errors printed to stdout instead of stderr).

### Bugs fixed

1. **`--top` string indexing bug**: `int(args.top[0])` indexed into the string value, so `--top 10` was parsed as `int("1") = 1` instead of `10`. Fixed by adding `type=int` to the argparse definition and using `args.top` directly.

2. **No validation for non-positive values**: `--top 0` and `--top -5` were silently accepted. Added an explicit check that rejects values < 1 with a clear error message.

3. **Errors printed to stdout**: All error messages (`Target not found`, `Regex error`, `Compare file not found`, `Build failed`) were using `print()` which outputs to stdout. Changed all error paths to use `file=sys.stderr`.

### Changes

- `oracletrace/cli.py`: Added `type=int` to `--top` argument, added positive integer validation, fixed `args.top[0]` → `args.top`, changed all error `print()` calls to use `file=sys.stderr`
- `tests/test_cli.py`: Updated existing tests to check `captured.err` instead of `captured.out`, added 4 new tests for `--top` validation (multi-digit values, zero, negative, non-integer)

## Test plan

- [x] All 12 tests pass (8 existing + 4 new)
- [x] `--top 5` works correctly (single digit)
- [x] `--top 10` works correctly (multi-digit — was broken before)
- [x] `--top 0` rejected with stderr message
- [x] `--top -5` rejected with stderr message
- [x] `--top foo` rejected by argparse with exit code 2
- [x] Error messages go to stderr, not stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)