### PR TITLE
feat: add repeat flag

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Filtering removes external/internal calls to focus on application code.
 
 ## Requirements
 
-* Python >= 3.10
+* Python >= 3.11
 * rich
 
 ---

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Add it to your CI to automatically fail on performance regressions.
 | `--threshold`          | Regression percentage threshold        |
 | `--ignore`             | Ignore functions/files via regex       |
 | `--top`                | Show top N functions                   |
+| `--repeat`             | Repeat the tracing N times             |
 
 ---
 

--- a/docs/docs/cli-reference.md
+++ b/docs/docs/cli-reference.md
@@ -14,6 +14,7 @@ Complete command reference for OracleTrace.
 oracletrace <target> [--json OUTPUT.json] [--csv OUTPUT.csv] [--html OUTPUT.html] [--compare BASELINE.json]
 oracletrace <target> [--ignore REGEX [REGEX ...]]
 oracletrace <target> [--top NUMBER]
+oracletrace <target> [--repeat NUMBER]
 oracletrace <target> [--compare BASELINE.json] [--fail-on-regression] [--threshold PERCENT] [--only-regressions]
 oracletrace --version
 ```
@@ -44,7 +45,7 @@ Use this when you want to keep historical traces or compare later.
 
 ### `--csv`
 
-Exports the trace results to a csv file.
+Exports the trace results to a CSV file.
 
 ```bash
 oracletrace my_app.py --csv run.csv
@@ -128,9 +129,17 @@ Limit the summary table output to a maximum number of results.
 oracletrace my_app.py --top 10
 ```
 
+### `--repeat`
+
+Repeat the trace N times to reduce noise and improve comparison accuracy.
+
+```bash
+oracletrace my_app.py --repeat 5
+```
+
 ### `--version`
 
-Prints version information and exit with a zero code.
+Prints version information and exits with code 0.
 
 ```bash
 oracletrace --version

--- a/oracletrace/cli.py
+++ b/oracletrace/cli.py
@@ -12,7 +12,7 @@ from argparse import ArgumentParser, Namespace
 
 from .reporters import generate_html_report
 from .compare import compare_traces, ComparisonData
-from .tracer import Tracer, TracerData, TracerMetadata
+from .tracer import Tracer, TracerData, TracerMetadata,FunctionData
 
 def main() -> int:
     module_name = __name__.split(".")[0]

--- a/oracletrace/cli.py
+++ b/oracletrace/cli.py
@@ -1,22 +1,19 @@
 import re
 import sys
 import os
+import csv
 import json
 import runpy
-import csv
+from re import Pattern
 from dataclasses import asdict
 from collections import defaultdict
-
-from .tracer import Tracer, TracerData, TracerMetadata, AggFunctionData
-from .compare import compare_traces, ComparisonData
-from typing import List, Dict, Any, Optional
-from re import Pattern
-from argparse import ArgumentParser, Namespace
 from importlib.metadata import version
+from typing import List, Dict, Optional
+from argparse import ArgumentParser, Namespace
+
 from .tracer import Tracer, TracerData
 from .compare import compare_traces, ComparisonData
 from .reporters import generate_html_report
-
 
 def main() -> int:
     module_name = __name__.split(".")[0]
@@ -120,10 +117,10 @@ def main() -> int:
 
     tracer, data = run_trace()
 
-    runs = int(args.repeat)
+    runs: int = int(args.repeat)
     if runs > 1:
-        total_time = 0
-        tracer_function_aggs = defaultdict(AggFunctionData)
+        total_time: float = 0
+        tracer_function_aggs: Dict[str, AggFunctionData] = defaultdict(AggFunctionData)
         for _ in range(runs):
             # Start tracing, run the script, then stop
             tracer, data = run_trace()
@@ -132,7 +129,7 @@ def main() -> int:
                 tracer_function_aggs[function_data.name].add(function_data)
                 total_time += function_data.total_time
 
-        tracer_agg = TracerData(
+        tracer_agg: TracerData = TracerData(
             metadata=TracerMetadata(
                 root_path=data.metadata.root_path,
                 total_functions=len(tracer_function_aggs),

--- a/oracletrace/cli.py
+++ b/oracletrace/cli.py
@@ -1,22 +1,21 @@
+import os
 import re
 import sys
-import os
 import csv
 import json
 import runpy
-import csv
 import argparse
-from dataclasses import asdict
-from typing import List, Dict, Any, Optional, Tuple
 from re import Pattern
+from statistics import median
 from dataclasses import asdict
 from importlib.metadata import version
-from typing import List, Dict, Optional, Tuple
 from argparse import ArgumentParser, Namespace
+from typing import List, Dict, Any, Optional, Tuple
 
 from .reporters import generate_html_report
 from .compare import compare_traces, ComparisonData
-from .tracer import Tracer, TracerData, TracerMetadata,FunctionData
+from .tracer import Tracer, TracerData, TracerMetadata, FunctionData, FunctionAggregate
+
 
 _MODULE_NAME: str = __name__.split(".")[0]
 
@@ -87,12 +86,24 @@ _BASE_PARSER.add_argument(
     action="store_true",
     help="Hide functions which didn't run slower than baseline. Use with --compare",
 )
+_BASE_PARSER.add_argument(
+    "--repeat",
+    metavar="NUMBER",
+    help="Number of times to repeat the trace run and aggregate results",
+    default=1,
+)
+
+
+def _set_default(obj: Any) -> Any:
+    if isinstance(obj, set):
+        return list(obj)
+    raise TypeError
 
 
 def _export_results(data: TracerData, args: Namespace) -> None:
     if args.json:
         with open(args.json, "w", encoding="utf-8") as f:
-            json.dump(asdict(data), f, indent=4)
+            json.dump(asdict(data), f, indent=4, default=_set_default)
 
     if args.csv:
         with open(args.csv, "w", newline="", encoding="utf-8") as f:
@@ -180,21 +191,18 @@ def _run_target() -> int:
         version=f"%(prog)s {version(_MODULE_NAME)}",
     )
 
-    parser.add_argument(
-        "--repeat",
-        metavar="NUMBER",
-        help="Number of times to run the trace against the previous trace JSON",
-        default=1
-    )
-
     args: Namespace = parser.parse_args()
-
     target: str = args.target
 
-    err, tracer = _init_tracer(args)
+    # Validate args before touching the filesystem or starting any tracer
+    top, err = _validate_top(args.top)
     if err is not None:
         return err
-    assert tracer is not None
+    args.top = top
+
+    ignore_patterns, err = _compile_ignore_patterns(args.ignore)
+    if err is not None:
+        return err
 
     if not os.path.exists(target):
         print(f"Target not found: {target}", file=sys.stderr)
@@ -204,63 +212,62 @@ def _run_target() -> int:
     target_dir: str = os.path.dirname(target)
     sys.path.insert(0, target_dir)
 
-    def run_trace():
-        _tracer: Tracer = Tracer(root, ignore_patterns=ignore_patterns)
+    # Capture root once so run_trace() closes over a stable value
+    root: str = os.getcwd()
 
+    def run_trace() -> Tuple[Tracer, TracerData]:
+        _tracer: Tracer = Tracer(root, ignore_patterns=ignore_patterns)
         _tracer.start()
         try:
             runpy.run_path(target, run_name="__main__")
         finally:
             _tracer.stop()
-
-        _data: TracerData = _tracer.get_trace_data()
-
-        return _tracer, _data
-
-    tracer, data = run_trace()
+        return _tracer, _tracer.get_trace_data()
 
     runs: int = int(args.repeat)
+
     if runs > 1:
-        total_time: float = 0
-        tracer_function_aggs: Dict[str, FunctionData] = {}
+        aggs: Dict[str, FunctionAggregate] = {}
+        wall_times: List[float] = []
+        data: TracerData
+
         for _ in range(runs):
-            # Start tracing, run the script, then stop
-            tracer, data = run_trace()
-
+            _, data = run_trace()
+            wall_times.append(data.metadata.total_execution_time)
             for function_data in data.functions:
-                if tracer_function_aggs.get(function_data.name) is None:
-                    tracer_function_aggs[function_data.name] = function_data
-                else:
-                    tracer_function_aggs[function_data.name].add(function_data)
-                total_time += function_data.total_time
+                if function_data.name not in aggs:
+                    aggs[function_data.name] = FunctionAggregate(name=function_data.name)
+                aggs[function_data.name].add(function_data)
 
-        tracer_agg: TracerData = TracerData(
+        data = TracerData(
             metadata=TracerMetadata(
                 root_path=data.metadata.root_path,
-                total_functions=len(tracer_function_aggs),
-                total_execution_time=total_time
+                total_functions=len(aggs),
+                total_execution_time=median(wall_times),
             ),
-            functions=list(tracer_function_aggs.values())
+            functions=[agg.to_function_data() for agg in aggs.values()],
         )
 
-        data = tracer_agg
+        _export_results(data, args)
+        exit_code = _compare_and_fail(data, args)
+        return exit_code if exit_code is not None else 0
+    else:
+        tracer, _ = run_trace()
+        exit_code = _finish_trace(tracer, args)
+        return exit_code if exit_code is not None else 0
 
-    def set_default(obj):
-        if isinstance(obj, set):
-            return list(obj)
-        raise TypeError
 
-    # Save json
-    if args.json:
-        with open(args.json, "w", encoding="utf-8") as f:
-            json.dump(asdict(data), f, indent=4, default=set_default)
-
-    # Display the analysis
-    if runs <= 1:
-        if args.top:
-            tracer.show_results(args.top)
-        else:
-            tracer.show_results(None)
+def _run_command(argv: List[str]) -> int:
+    parser: ArgumentParser = ArgumentParser(
+        prog=f"{_MODULE_NAME} run",
+        description="Run a command with OracleTrace tracing",
+        parents=[_BASE_PARSER],
+    )
+    parser.add_argument(
+        "command",
+        nargs=argparse.REMAINDER,
+        help="Command to run (e.g., pytest). Use -- to separate oracletrace options from the command.",
+    )
 
     parsed: Namespace = parser.parse_args(argv)
 
@@ -287,14 +294,6 @@ def _run_target() -> int:
         return 1
 
 
-
-        if args.fail_on_regression and comparison_result.has_regression:
-            print(
-                f"Build failed: performance regression above {args.threshold:.2f}% detected.",
-                file=sys.stderr,
-            )
-            return 2
-
 def _run_pytest(args: Namespace) -> int:
     try:
         import pytest
@@ -317,6 +316,7 @@ def _run_pytest(args: Namespace) -> int:
 
     exit_code = _finish_trace(tracer, args)
     return exit_code if exit_code is not None else pytest_exit_code
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/oracletrace/cli.py
+++ b/oracletrace/cli.py
@@ -5,6 +5,10 @@ import json
 import runpy
 import csv
 from dataclasses import asdict
+from collections import defaultdict
+
+from .tracer import Tracer, TracerData, TracerMetadata, AggFunctionData
+from .compare import compare_traces, ComparisonData
 from typing import List, Dict, Any, Optional
 from re import Pattern
 from argparse import ArgumentParser, Namespace
@@ -59,6 +63,14 @@ def main() -> int:
         help="Print version information then exit with a zero code",
         version=f"%(prog)s {version(module_name)}"
     )
+
+    parser.add_argument(
+        "--repeat",
+        metavar="NUMBER",
+        help="Number of times to run the trace against the previous trace JSON",
+        default=1
+    )
+
     args: Namespace = parser.parse_args()
 
     target: str = args.target
@@ -93,26 +105,60 @@ def main() -> int:
             print(f"Regex error: {pattern} -> {e}", file=sys.stderr)
             return 1
 
-    # Start tracing, run the script, then stop
-    tracer: Tracer = Tracer(root, ignore_patterns=ignore_patterns)
-    tracer.start()
-    try:
-        runpy.run_path(target, run_name="__main__")
-    finally:
-        tracer.stop()
+    def run_trace():
+        _tracer: Tracer = Tracer(root, ignore_patterns=ignore_patterns)
 
-    data: TracerData = tracer.get_trace_data()
+        _tracer.start()
+        try:
+            runpy.run_path(target, run_name="__main__")
+        finally:
+            _tracer.stop()
+
+        _data: TracerData = _tracer.get_trace_data()
+
+        return _tracer, _data
+
+    tracer, data = run_trace()
+
+    runs = int(args.repeat)
+    if runs > 1:
+        total_time = 0
+        tracer_function_aggs = defaultdict(AggFunctionData)
+        for _ in range(runs):
+            # Start tracing, run the script, then stop
+            tracer, data = run_trace()
+
+            for function_data in data.functions:
+                tracer_function_aggs[function_data.name].add(function_data)
+                total_time += function_data.total_time
+
+        tracer_agg = TracerData(
+            metadata=TracerMetadata(
+                root_path=data.metadata.root_path,
+                total_functions=len(tracer_function_aggs),
+                total_execution_time=total_time
+            ),
+            functions=list(tracer_function_aggs.values())
+        )
+
+        data = tracer_agg
+
+    def set_default(obj):
+        if isinstance(obj, set):
+            return list(obj)
+        raise TypeError
 
     # Save json
     if args.json:
         with open(args.json, "w", encoding="utf-8") as f:
-            json.dump(asdict(data), f, indent=4)
+            json.dump(asdict(data), f, indent=4, default=set_default)
 
     # Display the analysis
-    if args.top is not None:
-        tracer.show_results(args.top)
-    else:
-        tracer.show_results(None)
+    if runs <= 1:
+        if args.top:
+            tracer.show_results(int(args.top[0]))
+        else:
+            tracer.show_results(None)
 
     # Export as csv
     if args.csv:
@@ -151,7 +197,7 @@ def main() -> int:
                 file=sys.stderr,
             )
             return 2
-        
+
 
     return 0
 

--- a/oracletrace/cli.py
+++ b/oracletrace/cli.py
@@ -6,7 +6,6 @@ import json
 import runpy
 from re import Pattern
 from dataclasses import asdict
-from collections import defaultdict
 from importlib.metadata import version
 from typing import List, Dict, Optional
 from argparse import ArgumentParser, Namespace
@@ -120,13 +119,16 @@ def main() -> int:
     runs: int = int(args.repeat)
     if runs > 1:
         total_time: float = 0
-        tracer_function_aggs: Dict[str, AggFunctionData] = defaultdict(AggFunctionData)
+        tracer_function_aggs: Dict[str, FunctionData] = {}
         for _ in range(runs):
             # Start tracing, run the script, then stop
             tracer, data = run_trace()
 
             for function_data in data.functions:
-                tracer_function_aggs[function_data.name].add(function_data)
+                if tracer_function_aggs.get(function_data.name) is None:
+                    tracer_function_aggs[function_data.name] = function_data
+                else:
+                    tracer_function_aggs[function_data.name].add(function_data)
                 total_time += function_data.total_time
 
         tracer_agg: TracerData = TracerData(
@@ -195,9 +197,7 @@ def main() -> int:
             )
             return 2
 
-
     return 0
-
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/oracletrace/cli.py
+++ b/oracletrace/cli.py
@@ -10,9 +10,9 @@ from importlib.metadata import version
 from typing import List, Dict, Optional
 from argparse import ArgumentParser, Namespace
 
-from .tracer import Tracer, TracerData
-from .compare import compare_traces, ComparisonData
 from .reporters import generate_html_report
+from .compare import compare_traces, ComparisonData
+from .tracer import Tracer, TracerData, TracerMetadata
 
 def main() -> int:
     module_name = __name__.split(".")[0]
@@ -155,7 +155,7 @@ def main() -> int:
     # Display the analysis
     if runs <= 1:
         if args.top:
-            tracer.show_results(int(args.top[0]))
+            tracer.show_results(args.top)
         else:
             tracer.show_results(None)
 

--- a/oracletrace/tracer.py
+++ b/oracletrace/tracer.py
@@ -11,7 +11,8 @@ from typing import List, Optional, Callable, DefaultDict, Any, Tuple, Dict
 from re import Pattern
 from pathlib import Path
 from types import FrameType
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
 
 @dataclass
 class TracerMetadata:
@@ -20,17 +21,48 @@ class TracerMetadata:
     total_execution_time: float
 
 @dataclass
-class FunctionData:
-    name: str
-    total_time: float
-    call_count: int
-    avg_time: float
-    callees: List[str]
+class FunctionDataBase:
+    name: str | None = None
+    total_time: float | None = None
+    call_count: int | None = None
+    avg_time: float | None = None
+    callees: set[str] = field(default_factory=set)
+
+
+@dataclass
+class FunctionData(FunctionDataBase):
+    pass
+
+@dataclass
+class AggFunctionData(FunctionDataBase):
+    def add(self, trace: FunctionData) -> None:
+        if self.name is None:
+            self.name = trace.name
+        elif trace.name != self.name:
+            return
+
+        self.callees.update(trace.callees)
+
+        if self.total_time is None:
+            self.total_time = trace.total_time
+        else:
+            self.total_time = (self.total_time + trace.total_time) / 2
+
+        if self.call_count is None:
+            self.call_count = trace.call_count
+        else:
+            self.call_count = (self.call_count + trace.call_count) // 2
+
+        if self.avg_time is None:
+            self.avg_time = trace.avg_time
+        else:
+            self.avg_time = (self.avg_time + trace.avg_time) / 2
+
 
 @dataclass
 class TracerData:
     metadata: TracerMetadata
-    functions: List[FunctionData]
+    functions: List[FunctionDataBase]
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "TracerData":
@@ -229,14 +261,13 @@ class Tracer:
         for key, total_time in self._func_time.items():
             calls = self._func_calls[key]
             avg_time = total_time / calls if calls else 0
-
             functions.append(
                 FunctionData(
                     name = key,
                     total_time = total_time,
                     call_count = calls,
                     avg_time = avg_time,
-                    callees = list(self._call_map.get(key, {}).keys()),
+                    callees = {k for k in self._call_map.get(key, {}).keys()},
                 )
             )
 

--- a/oracletrace/tracer.py
+++ b/oracletrace/tracer.py
@@ -28,14 +28,16 @@ class FunctionData:
     avg_time: float
     callees: set[str] = field(default_factory=set)
 
-    def add(self, trace: type[Self]) -> None:
+    def add(self, trace: Self) -> None:
         if trace.name != self.name:
             return
 
         self.callees.update(trace.callees)
-        self.total_time = (self.total_time + trace.total_time) / 2
-        self.call_count = (self.call_count + trace.call_count) // 2
-        self.avg_time = (self.avg_time + trace.avg_time) / 2
+        self.total_time += trace.total_time
+        self.call_count += trace.call_count
+
+        if self.call_count:
+            self.avg_time = self.total_time / self.call_count
 
 @dataclass
 class TracerData:
@@ -46,7 +48,15 @@ class TracerData:
     def from_dict(cls, data: Dict[str, Any]) -> "TracerData":
         return cls(
             metadata=TracerMetadata(**data["metadata"]),
-            functions=[FunctionData(**f) for f in data["functions"]],
+            functions=[
+                FunctionData(
+                    **{
+                        **f,
+                        "callees": set(f.get("callees", [])),
+                    }
+                )
+                for f in data["functions"]
+            ],
         )
 
 class Tracer:

--- a/oracletrace/tracer.py
+++ b/oracletrace/tracer.py
@@ -6,13 +6,14 @@ import sysconfig
 from re import Pattern
 from pathlib import Path
 from types import FrameType
+from statistics import median
 from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import List, Optional, Callable, DefaultDict, Any, Tuple, Dict, Self
 
+from rich import print
 from rich.tree import Tree
 from rich.table import Table
-from rich import print
 
 @dataclass
 class TracerMetadata:
@@ -57,6 +58,30 @@ class TracerData:
                 )
                 for f in data["functions"]
             ],
+        )
+
+@dataclass
+class FunctionAggregate:
+    name: str
+    total_times: List[float] = field(default_factory=list)
+    call_counts: List[int] = field(default_factory=list)
+    callees: set[str] = field(default_factory=set)
+
+    def add(self, data: FunctionData) -> None:
+        self.total_times.append(data.total_time)
+        self.call_counts.append(data.call_count)
+        self.callees.update(data.callees)
+
+    def to_function_data(self) -> FunctionData:
+        total_time = median(self.total_times)
+        call_count = int(median(self.call_counts))
+
+        return FunctionData(
+            name=self.name,
+            total_time=total_time,
+            call_count=call_count,
+            avg_time=total_time / call_count if call_count else 0,
+            callees=self.callees,
         )
 
 class Tracer:

--- a/oracletrace/tracer.py
+++ b/oracletrace/tracer.py
@@ -1,17 +1,18 @@
-import sys
-import sysconfig
-import site
 import os
+import sys
+import site
 import time
+import sysconfig
+from re import Pattern
+from pathlib import Path
+from types import FrameType
 from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import List, Optional, Callable, DefaultDict, Any, Tuple, Dict, Self
+
 from rich.tree import Tree
 from rich.table import Table
 from rich import print
-from typing import List, Optional, Callable, DefaultDict, Any, Tuple, Dict, Self
-from re import Pattern
-from types import FrameType
-from dataclasses import dataclass, field
-
 
 @dataclass
 class TracerMetadata:

--- a/oracletrace/tracer.py
+++ b/oracletrace/tracer.py
@@ -9,7 +9,6 @@ from rich.table import Table
 from rich import print
 from typing import List, Optional, Callable, DefaultDict, Any, Tuple, Dict
 from re import Pattern
-from pathlib import Path
 from types import FrameType
 from dataclasses import dataclass, field
 
@@ -22,10 +21,10 @@ class TracerMetadata:
 
 @dataclass
 class FunctionDataBase:
-    name: str | None = None
-    total_time: float | None = None
-    call_count: int | None = None
-    avg_time: float | None = None
+    name: str = None
+    total_time: float = None
+    call_count: int = None
+    avg_time: float = None
     callees: set[str] = field(default_factory=set)
 
 
@@ -35,7 +34,7 @@ class FunctionData(FunctionDataBase):
 
 @dataclass
 class AggFunctionData(FunctionDataBase):
-    def add(self, trace: FunctionData) -> None:
+    def add(self, trace: FunctionDataBase) -> None:
         if self.name is None:
             self.name = trace.name
         elif trace.name != self.name:
@@ -68,7 +67,7 @@ class TracerData:
     def from_dict(cls, data: Dict[str, Any]) -> "TracerData":
         return cls(
             metadata=TracerMetadata(**data["metadata"]),
-            functions=[FunctionData(**f) for f in data["functions"]],
+            functions=[FunctionDataBase(**f) for f in data["functions"]],
         )
 
 class Tracer:
@@ -242,13 +241,13 @@ class Tracer:
             )
 
             for child_key, count in sorted_children:
-                total_time = self._func_time[child_key]
+                _total_time = self._func_time[child_key]
                 # Detect recursion to prevent infinite loops in the tree
                 if child_key in current_path:
                     parent_node.add(f"[red]↻ {child_key}[/] ({count}x)")
                     continue
 
-                node_text = f"{child_key} [dim]({count}x, {total_time:.4f}s)[/]"
+                node_text = f"{child_key} [dim]({count}x, {_total_time:.4f}s)[/]"
                 child_node = parent_node.add(node_text)
                 add_nodes(child_node, child_key, current_path | {child_key})
 

--- a/oracletrace/tracer.py
+++ b/oracletrace/tracer.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from rich.tree import Tree
 from rich.table import Table
 from rich import print
-from typing import List, Optional, Callable, DefaultDict, Any, Tuple, Dict
+from typing import List, Optional, Callable, DefaultDict, Any, Tuple, Dict, Self
 from re import Pattern
 from types import FrameType
 from dataclasses import dataclass, field
@@ -20,54 +20,32 @@ class TracerMetadata:
     total_execution_time: float
 
 @dataclass
-class FunctionDataBase:
-    name: str = None
-    total_time: float = None
-    call_count: int = None
-    avg_time: float = None
+class FunctionData:
+    name: str
+    total_time: float
+    call_count: int
+    avg_time: float
     callees: set[str] = field(default_factory=set)
 
-
-@dataclass
-class FunctionData(FunctionDataBase):
-    pass
-
-@dataclass
-class AggFunctionData(FunctionDataBase):
-    def add(self, trace: FunctionDataBase) -> None:
-        if self.name is None:
-            self.name = trace.name
-        elif trace.name != self.name:
+    def add(self, trace: type[Self]) -> None:
+        if trace.name != self.name:
             return
 
         self.callees.update(trace.callees)
-
-        if self.total_time is None:
-            self.total_time = trace.total_time
-        else:
-            self.total_time = (self.total_time + trace.total_time) / 2
-
-        if self.call_count is None:
-            self.call_count = trace.call_count
-        else:
-            self.call_count = (self.call_count + trace.call_count) // 2
-
-        if self.avg_time is None:
-            self.avg_time = trace.avg_time
-        else:
-            self.avg_time = (self.avg_time + trace.avg_time) / 2
-
+        self.total_time = (self.total_time + trace.total_time) / 2
+        self.call_count = (self.call_count + trace.call_count) // 2
+        self.avg_time = (self.avg_time + trace.avg_time) / 2
 
 @dataclass
 class TracerData:
     metadata: TracerMetadata
-    functions: List[FunctionDataBase]
+    functions: List[FunctionData]
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "TracerData":
         return cls(
             metadata=TracerMetadata(**data["metadata"]),
-            functions=[FunctionDataBase(**f) for f in data["functions"]],
+            functions=[FunctionData(**f) for f in data["functions"]],
         )
 
 class Tracer:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = ["rich"]
 
 [dependency-groups]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ import json
 import importlib
 import sys
 from pathlib import Path
-from oracletrace.tracer import TracerData, FunctionData, TracerMetadata
+from oracletrace.tracer import TracerData, FunctionData, TracerMetadata, FunctionDataBase
 from oracletrace.compare import ComparisonData
 from dataclasses import asdict
 import pytest
@@ -16,6 +16,11 @@ cli = importlib.import_module("oracletrace.cli")
 assert str(REPO_ROOT / "oracletrace") in str(Path(cli.__file__).resolve())
 
 
+def set_default(obj):
+    if isinstance(obj, set):
+        return list(obj)
+    raise TypeError
+
 @pytest.fixture
 def trace_data() -> TracerData:
     return TracerData(
@@ -25,14 +30,14 @@ def trace_data() -> TracerData:
             root_path = str(REPO_ROOT) 
         ),
         functions = [
-            FunctionData(
+            FunctionDataBase(
                 name = "foo",
                 total_time = 3.033,
                 call_count = 3,
                 avg_time = 1.011,
                 callees=[]
             ),
-            FunctionData(
+            FunctionDataBase(
                 name = "bar",
                 total_time = 2.0,
                 call_count = 2,
@@ -56,14 +61,14 @@ def baseline_trace_data() -> TracerData:
                 total_time = 1.5,
                 call_count = 3,
                 avg_time = 0.5,
-                callees=[]
+                callees=set()
             ),
             FunctionData(
                 name = "bar",
                 total_time = 2.0,
                 call_count = 2,
                 avg_time = 1.0,
-                callees=[]
+                callees=set()
             )
         ]
     )
@@ -340,7 +345,7 @@ def test_main_fails_with_exit_2_on_regression(monkeypatch, tmp_path, empty_trace
     target = tmp_path / "target.py"
     target.write_text("print('hello')\n", encoding="utf-8")
     compare_file = tmp_path / "baseline.json"
-    compare_file.write_text(json.dumps(asdict(empty_trace_data)), encoding="utf-8")
+    compare_file.write_text(json.dumps(asdict(empty_trace_data), default=set_default), encoding="utf-8")
 
     monkeypatch.setattr(cli, "Tracer", lambda root, ignore_patterns: FakeTracer(root, ignore_patterns, empty_trace_data))
     monkeypatch.setattr(cli.runpy, "run_path", lambda *args, **kwargs: None)
@@ -376,7 +381,7 @@ def test_main_returns_0_when_no_regression(monkeypatch, tmp_path, trace_data):
     target = tmp_path / "target.py"
     target.write_text("print('hello')\n", encoding="utf-8")
     compare_file = tmp_path / "baseline.json"
-    compare_file.write_text(json.dumps(asdict(trace_data)), encoding="utf-8")
+    compare_file.write_text(json.dumps(asdict(trace_data), default=set_default), encoding="utf-8")
 
     monkeypatch.setattr(cli, "Tracer", lambda root, ignore_patterns: FakeTracer(root, ignore_patterns, trace_data))
     monkeypatch.setattr(cli.runpy, "run_path", lambda *args, **kwargs: None)
@@ -406,7 +411,7 @@ def test_main_shows_only_regressions(monkeypatch, tmp_path, trace_data, baseline
     target = tmp_path / "target.py"
     target.write_text("print('hello')\n", encoding="utf-8")
     compare_file = tmp_path / "baseline.json"
-    compare_file.write_text(json.dumps(asdict(baseline_trace_data)), encoding="utf-8")
+    compare_file.write_text(json.dumps(asdict(baseline_trace_data), default=set_default), encoding="utf-8")
     
     monkeypatch.setattr(cli, "Tracer", lambda root, ignore_patterns: FakeTracer(root, ignore_patterns, trace_data))
     monkeypatch.setattr(cli.runpy, "run_path", lambda *args, **kwargs: None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ import json
 import importlib
 import sys
 from pathlib import Path
-from oracletrace.tracer import TracerData, FunctionData, TracerMetadata, FunctionDataBase
+from oracletrace.tracer import TracerData, FunctionData, TracerMetadata, FunctionData
 from oracletrace.compare import ComparisonData
 from dataclasses import asdict
 import pytest
@@ -30,14 +30,14 @@ def trace_data() -> TracerData:
             root_path = str(REPO_ROOT) 
         ),
         functions = [
-            FunctionDataBase(
+            FunctionData(
                 name = "foo",
                 total_time = 3.033,
                 call_count = 3,
                 avg_time = 1.011,
                 callees=[]
             ),
-            FunctionDataBase(
+            FunctionData(
                 name = "bar",
                 total_time = 2.0,
                 call_count = 2,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -475,9 +475,9 @@ def test_main_repeat_runs_trace_multiple_times(monkeypatch, tmp_path, trace_data
 
     assert exit_code == 0
 
-    assert run_count == 4
+    assert run_count == 3
 
-    assert len(tracer_instances) == 4
+    assert len(tracer_instances) == 3
     assert all(t.started for t in tracer_instances)
     assert all(t.stopped for t in tracer_instances)
     
@@ -530,8 +530,8 @@ def test_main_repeat_aggregates_function_times(monkeypatch, tmp_path):
 
     foo = exported.functions[0]
 
-    assert foo.total_time == 8.0
-    assert foo.call_count == 4
+    assert foo.total_time == 2.0
+    assert foo.call_count == 1
     
 def test_main_repeat_does_not_call_show_results(monkeypatch, tmp_path, trace_data):
     target = tmp_path / "target.py"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,18 +31,18 @@ def trace_data() -> TracerData:
         ),
         functions = [
             FunctionData(
-                name = "foo",
-                total_time = 3.033,
-                call_count = 3,
-                avg_time = 1.011,
-                callees=[]
+                name="foo",
+                total_time=2.0,
+                call_count=1,
+                avg_time=2.0,
+                callees=set(),
             ),
             FunctionData(
-                name = "bar",
-                total_time = 2.0,
-                call_count = 2,
-                avg_time = 1.0,
-                callees=[]
+                name="bar",
+                total_time=2.0,
+                call_count=2,
+                avg_time=1.0,
+                callees=set()
             )
         ]
     )
@@ -179,7 +179,7 @@ def test_main_runs_trace_and_exports_json_and_csv(monkeypatch, tmp_path, trace_d
 
     csv_text = csv_output.read_text(encoding="utf-8")
     assert "function,total_time,calls,avg_time" in csv_text
-    assert "foo,3.033,3,1.011" in csv_text
+    assert "foo,2.0,1,2.0" in csv_text
     assert "bar,2.0,2,1.0" in csv_text
 
     assert sys.path[0] == str(target.parent.resolve())
@@ -430,7 +430,7 @@ def test_main_shows_only_regressions(monkeypatch, tmp_path, trace_data, baseline
     captured = capsys.readouterr()
     assert f"{trace_data.functions[0].name}\n" in captured.out
     assert f"    total_time: {baseline_trace_data.functions[0].total_time:.4f}s → {trace_data.functions[0].total_time:.4f}s" in captured.out
-    assert f"(+{102.2:.2f}%)\n" in captured.out
+    assert f"(+{33.33:.2f}%)\n" in captured.out
     assert f"{trace_data.functions[1].name}\n" not in captured.out
 
 def test_main_prints_version_exits_0(monkeypatch, trace_data, capsys):
@@ -441,3 +441,153 @@ def test_main_prints_version_exits_0(monkeypatch, trace_data, capsys):
         captured = capsys.readouterr()
         assert exit_code == 0
         assert f"{module_name} {importlib.metadata.version(module_name)}" in captured.out
+
+
+def test_main_repeat_runs_trace_multiple_times(monkeypatch, tmp_path, trace_data):
+    target = tmp_path / "target.py"
+    target.write_text("print('hello')\n", encoding="utf-8")
+
+    tracer_instances = []
+
+    def tracer_factory(root, ignore_patterns):
+        fake = FakeTracer(root, ignore_patterns, trace_data)
+        tracer_instances.append(fake)
+        return fake
+
+    run_count = 0
+
+    def fake_run_path(*args, **kwargs):
+        nonlocal run_count
+        run_count += 1
+
+    monkeypatch.setattr(cli, "Tracer", tracer_factory)
+    monkeypatch.setattr(cli.runpy, "run_path", fake_run_path)
+
+    exit_code = _run_cli(
+        monkeypatch,
+        [
+            "oracletrace",
+            str(target),
+            "--repeat",
+            "3",
+        ],
+    )
+
+    assert exit_code == 0
+
+    assert run_count == 4
+
+    assert len(tracer_instances) == 4
+    assert all(t.started for t in tracer_instances)
+    assert all(t.stopped for t in tracer_instances)
+    
+def test_main_repeat_aggregates_function_times(monkeypatch, tmp_path):
+    target = tmp_path / "target.py"
+    target.write_text("print('hello')\n", encoding="utf-8")
+
+    trace_data = TracerData(
+        metadata=TracerMetadata(
+            total_execution_time=1.0,
+            total_functions=1,
+            root_path=str(REPO_ROOT),
+        ),
+        functions=[
+            FunctionData(
+                name="foo",
+                total_time=2.0,
+                call_count=1,
+                avg_time=2.0,
+                callees=set(),
+            )
+        ],
+    )
+
+    def tracer_factory(root, ignore_patterns):
+        return FakeTracer(root, ignore_patterns, trace_data)
+
+    monkeypatch.setattr(cli, "Tracer", tracer_factory)
+    monkeypatch.setattr(cli.runpy, "run_path", lambda *args, **kwargs: None)
+
+    output_json = tmp_path / "trace.json"
+
+    exit_code = _run_cli(
+        monkeypatch,
+        [
+            "oracletrace",
+            str(target),
+            "--repeat",
+            "3",
+            "--json",
+            str(output_json),
+        ],
+    )
+
+    assert exit_code == 0
+
+    exported = TracerData.from_dict(
+        json.loads(output_json.read_text())
+    )
+
+    foo = exported.functions[0]
+
+    assert foo.total_time == 8.0
+    assert foo.call_count == 4
+    
+def test_main_repeat_does_not_call_show_results(monkeypatch, tmp_path, trace_data):
+    target = tmp_path / "target.py"
+    target.write_text("print('hello')\n", encoding="utf-8")
+
+    fake_tracer_holder = {}
+
+    def tracer_factory(root, ignore_patterns):
+        fake = FakeTracer(root, ignore_patterns, trace_data)
+        fake_tracer_holder["instance"] = fake
+        return fake
+
+    monkeypatch.setattr(cli, "Tracer", tracer_factory)
+    monkeypatch.setattr(cli.runpy, "run_path", lambda *args, **kwargs: None)
+
+    exit_code = _run_cli(
+        monkeypatch,
+        [
+            "oracletrace",
+            str(target),
+            "--repeat",
+            "2",
+        ],
+    )
+
+    assert exit_code == 0
+
+    fake_tracer = fake_tracer_holder["instance"]
+
+    assert fake_tracer.show_results_calls == []
+    
+def test_main_repeat_one_behaves_like_default(monkeypatch, tmp_path, trace_data):
+    target = tmp_path / "target.py"
+    target.write_text("print('hello')\n", encoding="utf-8")
+
+    fake_tracer_holder = {}
+
+    def tracer_factory(root, ignore_patterns):
+        fake = FakeTracer(root, ignore_patterns, trace_data)
+        fake_tracer_holder["instance"] = fake
+        return fake
+
+    monkeypatch.setattr(cli, "Tracer", tracer_factory)
+    monkeypatch.setattr(cli.runpy, "run_path", lambda *args, **kwargs: None)
+
+    exit_code = _run_cli(
+        monkeypatch,
+        [
+            "oracletrace",
+            str(target),
+            "--repeat",
+            "1",
+        ],
+    )
+
+    assert exit_code == 0
+
+    fake_tracer = fake_tracer_holder["instance"]
+    assert fake_tracer.show_results_calls == [None]    


### PR DESCRIPTION
## Summary

Add repeat flag to aggregate trace results on repeated runs

## Related Issue

Link the related issue if available.

Implements #18 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] CLI behavior change

## What Changed

List the key changes in a few bullets.

- Added repeat flag
- Can compare against repeated runs and save repeated runs to json
- Will not print aggregated results to console for repeated runs

## Validation

Describe how you validated this change.

### CLI smoke check

```bash
oracletrace --help
```

### Functional trace run

```bash
oracletrace your_script.py
```

### JSON export and compare flow

```bash
oracletrace your_script.py --json baseline.json
oracletrace your_script.py --json current.json --compare baseline.json
```

### CSV, ignore, and top flags

```bash
oracletrace your_script.py --csv trace.csv
oracletrace your_script.py --ignore "helper_function,debug_*"
oracletrace your_script.py --top 10
```

### Docs build (if docs changed)

```bash
mkdocs build -f docs/mkdocs.yml
```

## Checklist

- [x] The code follows style conventions.
- [x] I added unit tests for the new functionality.
- [x] CI (GitHub Actions) is green.
- [x] I updated documentation/README when needed.

## Before/After Output (if applicable)

Include relevant CLI output snippets when behavior or formatting changed.

### Before

```text

```

### After

```text

```

## Additional Notes


Function results become the average of results. For example:
```json
            "name": "test.py:main",
            "total_time": 5.118640708737075,
            "call_count": 1,
            "avg_time": 5.118640708737075,
            "callees": [
                "test.py:process_data",
                "test.py:newfunc",
                "test.py:calculate_results"
            ]
```
call_count becomes the average amount of times this function is called per run. total_time becomes the average of total time the function spends in each run. avg_time is still the avg_time the individual function takes to run