### PR TITLE
feat: add --version flag

### DIFF
--- a/docs/docs/cli-reference.md
+++ b/docs/docs/cli-reference.md
@@ -15,6 +15,7 @@ oracletrace <target> [--json OUTPUT.json] [--csv OUTPUT.csv] [--compare BASELINE
 oracletrace <target> [--ignore REGEX [REGEX ...]]
 oracletrace <target> [--top NUMBER]
 oracletrace <target> [--compare BASELINE.json] [--fail-on-regression] [--threshold PERCENT] [--only-regressions]
+oracletrace --version
 ```
 
 ## Required argument
@@ -115,6 +116,14 @@ Limit the summary table output to a maximum number of results.
 
 ```bash
 oracletrace my_app.py --top 10
+```
+
+### `--version`
+
+Prints version information and exit with a zero code.
+
+```bash
+oracletrace --version
 ```
 
 ## Exit behavior

--- a/oracletrace/cli.py
+++ b/oracletrace/cli.py
@@ -11,10 +11,13 @@ from re import Pattern
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
 from dataclasses import asdict
+from importlib.metadata import version
 
 
 def main() -> int:
+    module_name = __name__.split(".")[0]
     parser: ArgumentParser  = ArgumentParser(
+        prog=module_name,
         description="OracleTrace - Lightweight execution tracer for Python projects"
     )
     parser.add_argument("target", help="Python script to trace")
@@ -47,6 +50,13 @@ def main() -> int:
         "--only-regressions",
         action="store_true",
         help="Hide functions which didn't run slower than baseline. Use with --compare"
+    )
+    
+    parser.add_argument(
+        "--version",
+        action="version",
+        help="Print version information then exit with a zero code",
+        version=f"%(prog)s {version(module_name)}"
     )
     args: Namespace = parser.parse_args()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -427,3 +427,12 @@ def test_main_shows_only_regressions(monkeypatch, tmp_path, trace_data, baseline
     assert f"    total_time: {baseline_trace_data.functions[0].total_time:.4f}s → {trace_data.functions[0].total_time:.4f}s" in captured.out
     assert f"(+{102.2:.2f}%)\n" in captured.out
     assert f"{trace_data.functions[1].name}\n" not in captured.out
+
+def test_main_prints_version_exits_0(monkeypatch, trace_data, capsys):
+    module_name = "oracletrace"
+    with pytest.raises(SystemExit):
+        exit_code = _run_cli(monkeypatch,["oracletrace","--version",])
+
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert f"{module_name} {importlib.metadata.version(module_name)}" in captured.out


### PR DESCRIPTION
## Summary

Adds a cli `--version` flag

## Related Issue

Closes #39 


## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [X] Documentation update
- [X] CLI behavior change

## What Changed

List the key changes in a few bullets.

- Adds a cli `--version` flag
- Adds a unit test for that change
- Adds an entry in the cli reference documentation

## Validation

- Run the new test that i have added in `test_cli.py`
- Rebuild and view the documentation

## Checklist

- [X] The code follows style conventions.
- [X] I added unit tests for the new functionality.
- [x] CI (GitHub Actions) is green.
- [ ] I updated documentation/README when needed.

## Before/After Output (if applicable)

Include relevant CLI output snippets when behavior or formatting changed.

### Before

```text
oracletrace --version
usage: oracletrace [-h] [--json JSON] [--compare COMPARE] [--csv CSV] [--ignore REGEX [REGEX ...]] [--top NUMBER] [--fail-on-regression] [--threshold THRESHOLD] [--only-regressions]
                   target
oracletrace: error: the following arguments are required: target
```

### After

```text
oracletrace --version
oracletrace 2.0.1

```
