### PR TITLE
feat: html report

### DIFF
--- a/docs/docs/cli-reference.md
+++ b/docs/docs/cli-reference.md
@@ -11,7 +11,7 @@ Complete command reference for OracleTrace.
 ## Command syntax
 
 ```bash
-oracletrace <target> [--json OUTPUT.json] [--csv OUTPUT.csv] [--compare BASELINE.json]
+oracletrace <target> [--json OUTPUT.json] [--csv OUTPUT.csv] [--html OUTPUT.html] [--compare BASELINE.json]
 oracletrace <target> [--ignore REGEX [REGEX ...]]
 oracletrace <target> [--top NUMBER]
 oracletrace <target> [--compare BASELINE.json] [--fail-on-regression] [--threshold PERCENT] [--only-regressions]
@@ -49,6 +49,16 @@ Exports the trace results to a csv file.
 ```bash
 oracletrace my_app.py --csv run.csv
 ```
+
+### `--html`
+
+Exports the trace results to an interactive HTML file.
+
+```bash
+oracletrace my_app.py --html report.html
+```
+
+The generated report includes a sortable table with function timing data and a call graph visualization.
 
 ### `--compare`
 

--- a/oracletrace/cli.py
+++ b/oracletrace/cli.py
@@ -4,14 +4,14 @@ import os
 import json
 import runpy
 import csv
-from .tracer import Tracer, TracerData
-from .compare import compare_traces, ComparisonData
+from dataclasses import asdict
 from typing import List, Dict, Any, Optional
 from re import Pattern
 from argparse import ArgumentParser, Namespace
-from pathlib import Path
-from dataclasses import asdict
 from importlib.metadata import version
+from .tracer import Tracer, TracerData
+from .compare import compare_traces, ComparisonData
+from .reporters import generate_html_report
 
 
 def main() -> int:
@@ -24,6 +24,7 @@ def main() -> int:
     parser.add_argument("--json", help="Export trace result to JSON file")
     parser.add_argument("--compare", help="Compare against previous trace JSON")
     parser.add_argument("--csv", help="Export trace result to CSV file")
+    parser.add_argument("--html", help="Export trace result to interactive HTML file")
     parser.add_argument(
         "--ignore",
         metavar="REGEX",
@@ -125,6 +126,11 @@ def main() -> int:
                     "calls":      fn.call_count,
                     "avg_time":   fn.avg_time,
                 })
+
+    # Generare a report as html
+    if args.html:
+        generate_html_report(data, args.html)
+        print(f"HTML report generated: {os.path.abspath(args.html)}")
 
     comparison_result: Optional[ComparisonData] = None
 

--- a/oracletrace/reporters/__init__.py
+++ b/oracletrace/reporters/__init__.py
@@ -1,0 +1,3 @@
+from .html import generate_html_report
+
+__all__ = ["generate_html_report"]

--- a/oracletrace/reporters/html.py
+++ b/oracletrace/reporters/html.py
@@ -1,0 +1,273 @@
+import json
+from datetime import datetime
+from string import Template
+from typing import List
+from ..tracer import TracerData, FunctionData
+
+
+class _JSTemplate(Template):
+    delimiter = "@"
+
+
+def generate_html_report(data: TracerData, output_path: str) -> None:
+    functions_json = _serialize_functions(data.functions)
+    metadata = data.metadata
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    html = _JSTemplate(_HTML_TEMPLATE).substitute(
+        root_path=metadata.root_path,
+        total_time=f"{metadata.total_execution_time:.4f}s",
+        total_functions=str(metadata.total_functions),
+        timestamp=timestamp,
+        functions_json=functions_json,
+    )
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(html)
+
+
+def _serialize_functions(functions: List[FunctionData]) -> str:
+    serialized = []
+    for fn in functions:
+        serialized.append({
+            "name": fn.name,
+            "total_time": fn.total_time,
+            "call_count": fn.call_count,
+            "avg_time": fn.avg_time * 1000,
+            "callees": fn.callees,
+        })
+    return json.dumps(serialized)
+
+
+_HTML_TEMPLATE = '''<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OracleTrace Report</title>
+    <style>
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            background: #f5f5f5;
+            color: #333;
+            padding: 20px;
+            line-height: 1.5;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+        header {
+            background: #fff;
+            padding: 20px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+        }
+        h1 {
+            font-size: 24px;
+            margin-bottom: 12px;
+            color: #1a1a1a;
+        }
+        .meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 20px;
+            font-size: 14px;
+            color: #666;
+        }
+        .meta-item {
+            display: flex;
+            flex-direction: column;
+        }
+        .meta-label {
+            font-weight: 600;
+            color: #333;
+        }
+        .meta-value {
+            color: #1a1a1a;
+        }
+        .controls {
+            margin-bottom: 16px;
+        }
+        #search {
+            width: 100%;
+            max-width: 400px;
+            padding: 10px 14px;
+            border: 1px solid #ddd;
+            border-radius: 6px;
+            font-size: 14px;
+        }
+        #search:focus {
+            outline: none;
+            border-color: #2563eb;
+            box-shadow: 0 0 0 3px rgba(37,99,235,0.1);
+        }
+        .table-container {
+            background: #fff;
+            border-radius: 8px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+            overflow: hidden;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 14px;
+        }
+        th {
+            text-align: left;
+            padding: 12px 16px;
+            background: #f8f9fa;
+            border-bottom: 2px solid #e5e7eb;
+            font-weight: 600;
+            cursor: pointer;
+            user-select: none;
+            white-space: nowrap;
+        }
+        th:hover {
+            background: #e9ecef;
+        }
+        th::after {
+            content: " ↕";
+            font-size: 12px;
+            color: #999;
+        }
+        th.sorted-asc::after {
+            content: " ↑";
+            color: #2563eb;
+        }
+        th.sorted-desc::after {
+            content: " ↓";
+            color: #2563eb;
+        }
+        td {
+            padding: 12px 16px;
+            border-bottom: 1px solid #e5e7eb;
+        }
+        tr:hover {
+            background: #f8f9fa;
+        }
+        .callee {
+            font-size: 12px;
+            color: #666;
+        }
+        .footer {
+            margin-top: 20px;
+            text-align: center;
+            font-size: 12px;
+            color: #999;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>OracleTrace Report</h1>
+            <div class="meta">
+                <div class="meta-item">
+                    <span class="meta-label">Project</span>
+                    <span class="meta-value">@root_path</span>
+                </div>
+                <div class="meta-item">
+                    <span class="meta-label">Total Time</span>
+                    <span class="meta-value">@total_time</span>
+                </div>
+                <div class="meta-item">
+                    <span class="meta-label">Functions</span>
+                    <span class="meta-value">@total_functions</span>
+                </div>
+                <div class="meta-item">
+                    <span class="meta-label">Generated</span>
+                    <span class="meta-value">@timestamp</span>
+                </div>
+            </div>
+        </header>
+        <div class="controls">
+            <input type="text" id="search" placeholder="Search functions..." autocomplete="off">
+        </div>
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr>
+                        <th data-sort="name" data-dir="asc">Function</th>
+                        <th data-sort="total_time" data-dir="desc">Total Time (s)</th>
+                        <th data-sort="call_count" data-dir="desc">Calls</th>
+                        <th data-sort="avg_time" data-dir="desc">Avg Time (ms)</th>
+                        <th>Callees</th>
+                    </tr>
+                </thead>
+                <tbody id="table-body">
+                </tbody>
+            </table>
+        </div>
+        <div class="footer">
+            Generated by OracleTrace
+        </div>
+    </div>
+    <script>
+        const functions = @functions_json;
+
+        let sortColumn = "total_time";
+        let sortDir = "desc";
+        let searchTerm = "";
+
+        function render() {
+            const filtered = functions.filter(f =>
+                f.name.toLowerCase().includes(searchTerm.toLowerCase())
+            );
+
+            filtered.sort((a, b) => {
+                const aVal = a[sortColumn];
+                const bVal = b[sortColumn];
+                if (aVal === bVal) return 0;
+                const compareResult = aVal > bVal ? 1 : -1;
+                return sortDir === "asc" ? compareResult : -compareResult;
+            });
+
+            const tbody = document.getElementById("table-body");
+            tbody.innerHTML = filtered.map(f => `
+                <tr>
+                    <td>${f.name}</td>
+                    <td>${f.total_time.toFixed(4)}</td>
+                    <td>${f.call_count}</td>
+                    <td>${f.avg_time.toFixed(4)}</td>
+                    <td class="callee">${f.callees.join(", ")}</td>
+                </tr>
+            `).join("");
+
+            document.querySelectorAll("th").forEach(th => {
+                th.classList.remove("sorted-asc", "sorted-desc");
+                if (th.dataset.sort === sortColumn) {
+                    th.classList.add(`sorted-${sortDir}`);
+                }
+            });
+        }
+
+        document.querySelectorAll("th[data-sort]").forEach(th => {
+            th.addEventListener("click", () => {
+                const col = th.dataset.sort;
+                if (sortColumn === col) {
+                    sortDir = sortDir === "asc" ? "desc" : "asc";
+                } else {
+                    sortColumn = col;
+                    sortDir = "desc";
+                }
+                render();
+            });
+        });
+
+        document.getElementById("search").addEventListener("input", (e) => {
+            searchTerm = e.target.value;
+            render();
+        });
+
+        render();
+    </script>
+</body>
+</html>
+'''

--- a/tests/test_html_reporter.py
+++ b/tests/test_html_reporter.py
@@ -1,0 +1,125 @@
+import pytest
+from oracletrace.tracer import TracerData, TracerMetadata, FunctionData
+from oracletrace.reporters.html import generate_html_report
+
+
+@pytest.fixture
+def sample_trace_data():
+    return TracerData(
+        metadata=TracerMetadata(
+            root_path="/test/project",
+            total_functions=3,
+            total_execution_time=1.5
+        ),
+        functions=[
+            FunctionData(
+                name="main.py:main",
+                total_time=1.0,
+                call_count=1,
+                avg_time=1.0,
+                callees=["main.py:helper"]
+            ),
+            FunctionData(
+                name="main.py:helper",
+                total_time=0.4,
+                call_count=3,
+                avg_time=0.133,
+                callees=["main.py:compute"]
+            ),
+            FunctionData(
+                name="main.py:compute",
+                total_time=0.1,
+                call_count=10,
+                avg_time=0.01,
+                callees=[]
+            )
+        ]
+    )
+
+
+def test_generate_html_report(sample_trace_data, tmp_path):
+    output_path = str(tmp_path / "report.html")
+    generate_html_report(sample_trace_data, output_path)
+
+    content = tmp_path.joinpath("report.html").read_text(encoding="utf-8")
+
+    assert "<!DOCTYPE html>" in content
+    assert "OracleTrace Report" in content
+    assert "/test/project" in content
+    assert "1.5" in content
+    assert "3" in content
+
+
+def test_html_report_contains_table_columns(sample_trace_data, tmp_path):
+    output_path = str(tmp_path / "report.html")
+    generate_html_report(sample_trace_data, output_path)
+
+    content = tmp_path.joinpath("report.html").read_text(encoding="utf-8")
+
+    assert "Function</th>" in content
+    assert "Total Time (s)</th>" in content
+    assert "Calls</th>" in content
+    assert "Avg Time (ms)</th>" in content
+    assert "Callees</th>" in content
+
+
+def test_html_report_is_standalone(sample_trace_data, tmp_path):
+    output_path = str(tmp_path / "report.html")
+    generate_html_report(sample_trace_data, output_path)
+
+    content = tmp_path.joinpath("report.html").read_text(encoding="utf-8")
+
+    assert "https://" not in content and "http://" not in content
+
+
+def test_html_report_contains_function_names(sample_trace_data, tmp_path):
+    output_path = str(tmp_path / "report.html")
+    generate_html_report(sample_trace_data, output_path)
+
+    content = tmp_path.joinpath("report.html").read_text(encoding="utf-8")
+
+    assert "main.py:main" in content
+    assert "main.py:helper" in content
+    assert "main.py:compute" in content
+
+
+def test_html_report_callees_rendered(sample_trace_data, tmp_path):
+    output_path = str(tmp_path / "report.html")
+    generate_html_report(sample_trace_data, output_path)
+
+    content = tmp_path.joinpath("report.html").read_text(encoding="utf-8")
+
+    assert "main.py:helper" in content
+    assert "main.py:compute" in content
+    assert "callees" in content.lower() or "callee" in content.lower()
+
+
+def test_html_report_uses_template_delimiter(sample_trace_data, tmp_path):
+    output_path = str(tmp_path / "report.html")
+    generate_html_report(sample_trace_data, output_path)
+
+    content = tmp_path.joinpath("report.html").read_text(encoding="utf-8")
+
+    # Placeholders should be replaced - @ should not appear as a placeholder
+    # (it would only remain if substitution failed)
+    assert "@root_path" not in content
+    assert "@total_time" not in content
+    assert "@functions_json" not in content
+
+
+def test_html_report_empty_functions(sample_trace_data, tmp_path):
+    empty_data = TracerData(
+        metadata=TracerMetadata(
+            root_path="/empty",
+            total_functions=0,
+            total_execution_time=0.0
+        ),
+        functions=[]
+    )
+    output_path = str(tmp_path / "report.html")
+    generate_html_report(empty_data, output_path)
+
+    content = tmp_path.joinpath("report.html").read_text(encoding="utf-8")
+
+    assert "[]" in content
+    assert "/empty" in content


### PR DESCRIPTION
## Summary

Adds the `--html` cli flag

## Related Issue


Closes #35 

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [X] Documentation update
- [X] CLI behavior change

## What Changed

List the key changes in a few bullets.

- New module for reporting with a html reporter.
- New unit test
- Docs update

## Validation

- Added a test case

## Checklist

- [X] The code follows style conventions.
- [X] I added unit tests for the new functionality.
- [x] CI (GitHub Actions) is green.
- [ ] I updated documentation/README when needed.

## Before/After Output (if applicable)

### After

```text
oracletrace sample.py --html index.html 
Summary:
Total execution time: 0.6038s
                         Top functions by Total Time                          
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┓
┃ Function                    ┃ Total Time (s) ┃ Calls ┃ Avg. Time/Call (ms) ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━┩
│ sample.py:<module>          │         0.6009 │     1 │             600.902 │
│ sample.py:main              │         0.6009 │     1 │             600.871 │
│ sample.py:process_data      │         0.6008 │     2 │             300.378 │
│ sample.py:calculate_results │         0.4003 │     2 │             200.132 │
└─────────────────────────────┴────────────────┴───────┴─────────────────────┘

Logic Flow:
<module>
├── sample.py:<module> (1x, 0.6009s)
│   └── sample.py:main (1x, 0.6009s)
│       └── sample.py:process_data (2x, 0.6008s)
│           └── sample.py:calculate_results (2x, 0.4003s)
└── oracletrace/tracer.py:Tracer.stop (1x, 0.0000s)
HTML report generated: /home/raphael/src/oracletrace/index.html
```

<img width="1916" height="514" alt="image" src="https://github.com/user-attachments/assets/8cbb5842-518d-4451-a228-f89c2c055478" />
