### PR TITLE
feat: pytest integration (oracletrace run -- pytest)

### DIFF
--- a/docs/docs/cli-reference.md
+++ b/docs/docs/cli-reference.md
@@ -16,11 +16,14 @@ oracletrace <target> [--ignore REGEX [REGEX ...]]
 oracletrace <target> [--top NUMBER]
 oracletrace <target> [--compare BASELINE.json] [--fail-on-regression] [--threshold PERCENT] [--only-regressions]
 oracletrace --version
+oracletrace run [options] -- pytest [pytest-args...]
 ```
 
-## Required argument
+## Tracing a Python script
 
-### `target`
+### Required argument
+
+#### `target`
 
 Path to the Python script you want to trace.
 
@@ -29,6 +32,29 @@ Example:
 ```bash
 oracletrace my_app.py
 ```
+
+## Running a command with `oracletrace run`
+
+The `run` subcommand lets you trace commands like `pytest` instead of a single script.
+
+```bash
+oracletrace run [options] -- pytest [pytest-args...]
+```
+
+All standard OracleTrace options (`--json`, `--csv`, `--html`, `--compare`, `--fail-on-regression`, `--threshold`, `--ignore`, `--top`) work with `run`. Use `--` to separate OracleTrace options from the command and its arguments.
+
+Example:
+
+```bash
+oracletrace run --json trace.json -- pytest tests/ -x -v
+```
+
+### Behaviour
+
+- OracleTrace starts tracing, then calls `pytest.main()` in-process with the provided arguments
+- Trace data is captured across all user code exercised by the test suite
+- If `--fail-on-regression` is set and a regression is detected, the exit code is `2` regardless of the pytest exit code
+- If no regression is detected, the pytest exit code is propagated
 
 ## Optional arguments
 
@@ -138,13 +164,13 @@ oracletrace --version
 
 ## Exit behavior
 
-OracleTrace returns a non-zero exit code when:
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Success |
+| `1` | OracleTrace error (invalid arguments, missing files, etc.) **or** traced command error (e.g. pytest failures) when no regression is detected |
+| `2` | Performance regression detected (`--fail-on-regression`) |
 
-- The target script does not exist
-- The compare JSON file does not exist
-- `--fail-on-regression` is enabled and at least one function regresses above the threshold
-
-Non-zero exit codes can also happen when the target script fails at runtime or when the compare JSON file cannot be parsed.
+When `--fail-on-regression` finds a regression, exit code `2` takes priority over the traced command's exit code. Otherwise the traced command's exit code is propagated.
 
 ## Typical workflows
 
@@ -163,6 +189,18 @@ oracletrace app.py --json current.json --compare baseline.json --fail-on-regress
 ```
 
 Store `baseline.json` as a known-good artifact.
+
+### CI regression workflow with pytest
+
+```bash
+# Generate baseline from a stable branch
+oracletrace run --json baseline.json -- pytest tests/ -q
+
+# Compare in a PR pipeline
+oracletrace run --json current.json --compare baseline.json --fail-on-regression --threshold 25 -- pytest tests/ -q
+```
+
+This enables OracleTrace to act as a performance guardrail in test pipelines without modifying test code.
 
 ## Tips
 

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -109,6 +109,23 @@ oracletrace my_script.py --json current.json --compare baseline.json --fail-on-r
 
 Use this when you want a simple, scriptable guardrail before merging changes.
 
+## Trace pytest test suites
+
+```bash
+oracletrace run -- pytest tests/ -q
+```
+
+All standard options work with `run`:
+
+```bash
+oracletrace run --json baseline.json -- pytest tests/ -q
+```
+
+Best for:
+
+- Performance regression detection in CI without test-level instrumentation
+- Tracing across multiple test files with a single command
+
 ## Read the logic flow tree
 
 Typical output shape:

--- a/oracletrace/cli.py
+++ b/oracletrace/cli.py
@@ -4,8 +4,9 @@ import os
 import json
 import runpy
 import csv
+import argparse
 from dataclasses import asdict
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Tuple
 from re import Pattern
 from argparse import ArgumentParser, Namespace
 from importlib.metadata import version
@@ -14,146 +15,252 @@ from .compare import compare_traces, ComparisonData
 from .reporters import generate_html_report
 
 
+_MODULE_NAME: str = __name__.split(".")[0]
+
+
 def main() -> int:
-    module_name = __name__.split(".")[0]
-    parser: ArgumentParser  = ArgumentParser(
-        prog=module_name,
-        description="OracleTrace - Lightweight execution tracer for Python projects"
-    )
-    parser.add_argument("target", help="Python script to trace")
-    parser.add_argument("--json", help="Export trace result to JSON file")
-    parser.add_argument("--compare", help="Compare against previous trace JSON")
-    parser.add_argument("--csv", help="Export trace result to CSV file")
-    parser.add_argument("--html", help="Export trace result to interactive HTML file")
-    parser.add_argument(
-        "--ignore",
-        metavar="REGEX",
-        nargs="+",
-        help="Space separated list of regex patterns for keys (file path and function name) to ignore."
-    )
-    parser.add_argument(
-        "--top",
-        metavar="NUMBER",
-        help="Limits the number of functions shown in the summary table"
-    )
-    parser.add_argument(
+    if len(sys.argv) >= 2 and sys.argv[1] == "run":
+        return _run_command(sys.argv[2:])
+    return _run_target()
+
+
+def _validate_top(top_str: Optional[str]) -> Tuple[Optional[int], Optional[int]]:
+    if top_str is None:
+        return None, None
+    try:
+        top = int(top_str)
+        if top < 1:
+            raise ValueError
+    except ValueError:
+        print(f"argument --top: invalid int value: '{top_str}'", file=sys.stderr)
+        return None, 1
+    return top, None
+
+
+def _compile_ignore_patterns(
+    patterns: Optional[List[str]],
+) -> Tuple[Optional[List[Pattern]], Optional[int]]:
+    if not patterns:
+        return [], None
+    compiled: List[Pattern] = []
+    for pattern in patterns:
+        try:
+            compiled.append(re.compile(pattern))
+        except re.error as e:
+            print(f"Regex error: {pattern} -> {e}", file=sys.stderr)
+            return None, 1
+    return compiled, None
+
+
+_BASE_PARSER: ArgumentParser = ArgumentParser(add_help=False)
+_BASE_PARSER.add_argument("--json", help="Export trace result to JSON file")
+_BASE_PARSER.add_argument("--csv", help="Export trace result to CSV file")
+_BASE_PARSER.add_argument("--html", help="Export trace result to interactive HTML file")
+_BASE_PARSER.add_argument("--compare", help="Compare against previous trace JSON")
+_BASE_PARSER.add_argument(
+    "--ignore",
+    metavar="REGEX",
+    nargs="+",
+    help="Space separated list of regex patterns for keys (file path and function name) to ignore.",
+)
+_BASE_PARSER.add_argument(
+    "--top",
+    metavar="NUMBER",
+    help="Limits the number of functions shown in the summary table",
+)
+_BASE_PARSER.add_argument(
     "--fail-on-regression",
     action="store_true",
     help="Exit with a non-zero code when regression exceeds threshold.",
+)
+_BASE_PARSER.add_argument(
+    "--threshold",
+    type=float,
+    default=5.0,
+    help="Regression threshold percentage used with --fail-on-regression.",
+)
+_BASE_PARSER.add_argument(
+    "--only-regressions",
+    action="store_true",
+    help="Hide functions which didn't run slower than baseline. Use with --compare",
+)
+
+
+def _export_results(data: TracerData, args: Namespace) -> None:
+    if args.json:
+        with open(args.json, "w", encoding="utf-8") as f:
+            json.dump(asdict(data), f, indent=4)
+
+    if args.csv:
+        with open(args.csv, "w", newline="", encoding="utf-8") as f:
+            writer: csv.DictWriter = csv.DictWriter(
+                f, fieldnames=["function", "total_time", "calls", "avg_time"]
+            )
+            writer.writeheader()
+            for fn in data.functions:
+                writer.writerow({
+                    "function": fn.name,
+                    "total_time": fn.total_time,
+                    "calls": fn.call_count,
+                    "avg_time": fn.avg_time,
+                })
+
+    if args.html:
+        generate_html_report(data, args.html)
+        print(f"HTML report generated: {os.path.abspath(args.html)}")
+
+
+def _compare_and_fail(
+    data: TracerData, args: Namespace
+) -> Optional[int]:
+    if not args.compare:
+        return None
+
+    if not os.path.exists(args.compare):
+        print(f"Compare file not found: {args.compare}", file=sys.stderr)
+        return 1
+
+    with open(args.compare, "r", encoding="utf-8") as f:
+        old_data: TracerData = TracerData.from_dict(json.load(f))
+
+    comparison_result: ComparisonData = compare_traces(
+        old_data,
+        data,
+        threshold=args.threshold,
+        show_only_regressions=args.only_regressions,
     )
-    parser.add_argument(
-        "--threshold",
-        type=float,
-        default=5.0,
-        help="Regression threshold percentage used with --fail-on-regression.",
+
+    if args.fail_on_regression and comparison_result.has_regression:
+        print(
+            f"Build failed: performance regression above {args.threshold:.2f}% detected.",
+            file=sys.stderr,
+        )
+        return 2
+
+    return None
+
+
+def _init_tracer(args: Namespace) -> Tuple[Optional[int], Optional[Tracer]]:
+    top, err = _validate_top(args.top)
+    if err is not None:
+        return err, None
+    args.top = top
+
+    ignore_patterns, err = _compile_ignore_patterns(args.ignore)
+    if err is not None:
+        return err, None
+
+    tracer = Tracer(os.getcwd(), ignore_patterns=ignore_patterns)
+    tracer.start()
+    return None, tracer
+
+
+def _finish_trace(tracer: Tracer, args: Namespace) -> Optional[int]:
+    data = tracer.get_trace_data()
+    _export_results(data, args)
+    tracer.show_results(args.top)
+    return _compare_and_fail(data, args)
+
+
+def _run_target() -> int:
+    parser: ArgumentParser = ArgumentParser(
+        prog=_MODULE_NAME,
+        description="OracleTrace - Lightweight execution tracer for Python projects",
+        epilog="Subcommands:\n  run  Run a command (e.g., pytest) with tracing. See 'oracletrace run --help'.",
+        parents=[_BASE_PARSER],
     )
-    parser.add_argument(
-        "--only-regressions",
-        action="store_true",
-        help="Hide functions which didn't run slower than baseline. Use with --compare"
-    )
-    
+    parser.add_argument("target", help="Python script to trace")
     parser.add_argument(
         "--version",
         action="version",
         help="Print version information then exit with a zero code",
-        version=f"%(prog)s {version(module_name)}"
+        version=f"%(prog)s {version(_MODULE_NAME)}",
     )
     args: Namespace = parser.parse_args()
 
     target: str = args.target
 
-    # Validate --top argument manually to ensure all paths are testable
-    if args.top is not None:
-        try:
-            args.top = int(args.top)
-        except ValueError:
-            print(f"argument --top: invalid int value: '{args.top}'", file=sys.stderr)
-            return 2
-        if args.top < 1:
-            print(f"--top must be a positive integer, got: {args.top}", file=sys.stderr)
-            return 1
+    err, tracer = _init_tracer(args)
+    if err is not None:
+        return err
+    assert tracer is not None
 
     if not os.path.exists(target):
         print(f"Target not found: {target}", file=sys.stderr)
         return 1
 
     target = os.path.abspath(target)
-    root: str = os.getcwd()
     target_dir: str = os.path.dirname(target)
-    # Setup paths so imports work correctly in the target script
     sys.path.insert(0, target_dir)
-    ignored_args: List[str] = [] if args.ignore is None else args.ignore
-    ignore_patterns: List[Pattern] = []
 
-    for pattern in ignored_args:
-        try:
-            ignore_patterns.append(re.compile(pattern))
-        except re.error as e:
-            print(f"Regex error: {pattern} -> {e}", file=sys.stderr)
-            return 1
-
-    # Start tracing, run the script, then stop
-    tracer: Tracer = Tracer(root, ignore_patterns=ignore_patterns)
-    tracer.start()
     try:
         runpy.run_path(target, run_name="__main__")
     finally:
         tracer.stop()
 
-    data: TracerData = tracer.get_trace_data()
+    exit_code = _finish_trace(tracer, args)
+    return exit_code if exit_code is not None else 0
 
-    # Save json
-    if args.json:
-        with open(args.json, "w", encoding="utf-8") as f:
-            json.dump(asdict(data), f, indent=4)
 
-    # Display the analysis
-    if args.top is not None:
-        tracer.show_results(args.top)
+def _run_command(argv: List[str]) -> int:
+    parser: ArgumentParser = ArgumentParser(
+        prog=f"{_MODULE_NAME} run",
+        description="Run a command with OracleTrace tracing",
+        parents=[_BASE_PARSER],
+    )
+    parser.add_argument(
+        "command",
+        nargs=argparse.REMAINDER,
+        help="Command to run (e.g., pytest). Use -- to separate oracletrace options from the command.",
+    )
+
+    parsed: Namespace = parser.parse_args(argv)
+
+    if parsed.command and parsed.command[0] == "--":
+        parsed.command = parsed.command[1:]
+
+    if not parsed.command:
+        print(
+            "error: no command specified. "
+            "Usage: oracletrace run [options] -- <command> [args...]",
+            file=sys.stderr,
+        )
+        return 1
+
+    cmd: str = parsed.command[0]
+
+    if cmd == "pytest":
+        return _run_pytest(parsed)
     else:
-        tracer.show_results(None)
+        print(
+            f"error: unsupported command '{cmd}'. Only 'pytest' is supported.",
+            file=sys.stderr,
+        )
+        return 1
 
-    # Export as csv
-    if args.csv:
-        with open(args.csv, "w", newline="", encoding="utf-8") as f:
-            writer: csv.DictWriter = csv.DictWriter(f, fieldnames=["function", "total_time", "calls", "avg_time"])
-            writer.writeheader()
-            for fn in data.functions:
-                writer.writerow({
-                    "function":   fn.name,
-                    "total_time": fn.total_time,
-                    "calls":      fn.call_count,
-                    "avg_time":   fn.avg_time,
-                })
 
-    # Generare a report as html
-    if args.html:
-        generate_html_report(data, args.html)
-        print(f"HTML report generated: {os.path.abspath(args.html)}")
+def _run_pytest(args: Namespace) -> int:
+    try:
+        import pytest
+    except ImportError:
+        print(
+            "error: pytest is not installed. Install it with: pip install pytest",
+            file=sys.stderr,
+        )
+        return 1
 
-    comparison_result: Optional[ComparisonData] = None
+    err, tracer = _init_tracer(args)
+    if err is not None:
+        return err
+    assert tracer is not None
 
-    # Compare jsons
-    if args.compare:
-        if not os.path.exists(args.compare):
-            print(f"Compare file not found: {args.compare}", file=sys.stderr)
-            return 1
+    try:
+        pytest_exit_code: int = pytest.main(args.command[1:])
+    finally:
+        tracer.stop()
 
-        with open(args.compare, "r", encoding="utf-8") as f:
-            old_data: TracerData = TracerData.from_dict(json.load(f))
-
-        comparison_result = compare_traces(old_data, data, threshold=args.threshold, show_only_regressions=args.only_regressions)
-
-        if args.fail_on_regression and comparison_result.has_regression:
-            print(
-                f"Build failed: performance regression above {args.threshold:.2f}% detected.",
-                file=sys.stderr,
-            )
-            return 2
-        
-
-    return 0
+    exit_code = _finish_trace(tracer, args)
+    return exit_code if exit_code is not None else pytest_exit_code
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -230,7 +230,7 @@ def test_main_rejects_zero_top(monkeypatch, tmp_path, capsys):
 
     captured = capsys.readouterr()
     assert exit_code == 1
-    assert "--top must be a positive integer" in captured.err
+    assert "argument --top: invalid int value" in captured.err
 
 
 def test_main_rejects_negative_top(monkeypatch, tmp_path, capsys):
@@ -241,7 +241,7 @@ def test_main_rejects_negative_top(monkeypatch, tmp_path, capsys):
 
     captured = capsys.readouterr()
     assert exit_code == 1
-    assert "--top must be a positive integer" in captured.err
+    assert "argument --top: invalid int value" in captured.err
 
 
 def test_main_rejects_non_integer_top(monkeypatch, tmp_path, capsys):
@@ -251,7 +251,7 @@ def test_main_rejects_non_integer_top(monkeypatch, tmp_path, capsys):
     exit_code = _run_cli(monkeypatch, ["oracletrace", str(target), "--top", "foo"])
 
     captured = capsys.readouterr()
-    assert exit_code == 2
+    assert exit_code == 1
     assert "invalid int value" in captured.err
 
 
@@ -262,7 +262,7 @@ def test_main_rejects_float_top(monkeypatch, tmp_path, capsys):
     exit_code = _run_cli(monkeypatch, ["oracletrace", str(target), "--top", "3.5"])
 
     captured = capsys.readouterr()
-    assert exit_code == 2
+    assert exit_code == 1
     assert "invalid int value" in captured.err
 
 
@@ -273,7 +273,7 @@ def test_main_rejects_empty_top(monkeypatch, tmp_path, capsys):
     exit_code = _run_cli(monkeypatch, ["oracletrace", str(target), "--top", ""])
 
     captured = capsys.readouterr()
-    assert exit_code == 2
+    assert exit_code == 1
     assert "invalid int value" in captured.err
 
 
@@ -436,3 +436,83 @@ def test_main_prints_version_exits_0(monkeypatch, trace_data, capsys):
         captured = capsys.readouterr()
         assert exit_code == 0
         assert f"{module_name} {importlib.metadata.version(module_name)}" in captured.out
+
+
+
+def test_run_missing_command(monkeypatch, capsys):
+    exit_code = _run_cli(monkeypatch, ["oracletrace", "run"])
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "no command specified" in captured.err
+
+
+def test_run_unsupported_command(monkeypatch, capsys):
+    exit_code = _run_cli(monkeypatch, ["oracletrace", "run", "--", "mycmd"])
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "unsupported command" in captured.err
+
+
+def test_run_pytest_basic(monkeypatch, empty_trace_data):
+    fake_tracer_holder: dict = {}
+    def tracer_factory(root, ignore_patterns):
+        fake = FakeTracer(root, ignore_patterns, empty_trace_data)
+        fake_tracer_holder["instance"] = fake
+        return fake
+    monkeypatch.setattr(cli, "Tracer", tracer_factory)
+
+    pytest_calls: list = []
+    def fake_pytest_main(args=None):
+        pytest_calls.append(args)
+        return 0
+    monkeypatch.setattr(pytest, "main", fake_pytest_main)
+
+    exit_code = _run_cli(monkeypatch, ["oracletrace", "run", "--", "pytest"])
+
+    fake_tracer = fake_tracer_holder["instance"]
+    assert exit_code == 0
+    assert fake_tracer.started is True
+    assert fake_tracer.stopped is True
+    assert pytest_calls == [[]]
+
+
+def test_run_pytest_passes_args(monkeypatch, empty_trace_data):
+    fake_tracer_holder: dict = {}
+    def tracer_factory(root, ignore_patterns):
+        fake = FakeTracer(root, ignore_patterns, empty_trace_data)
+        fake_tracer_holder["instance"] = fake
+        return fake
+    monkeypatch.setattr(cli, "Tracer", tracer_factory)
+
+    pytest_calls: list = []
+    def fake_pytest_main(args=None):
+        pytest_calls.append(args)
+        return 0
+    monkeypatch.setattr(pytest, "main", fake_pytest_main)
+
+    exit_code = _run_cli(
+        monkeypatch,
+        ["oracletrace", "run", "--", "pytest", "-x", "-v", "tests/"],
+    )
+
+    assert exit_code == 0
+    assert pytest_calls == [["-x", "-v", "tests/"]]
+
+
+def test_run_pytest_propagates_pytest_exit_code(monkeypatch, empty_trace_data):
+    fake_tracer_holder: dict = {}
+    def tracer_factory(root, ignore_patterns):
+        fake = FakeTracer(root, ignore_patterns, empty_trace_data)
+        fake_tracer_holder["instance"] = fake
+        return fake
+    monkeypatch.setattr(cli, "Tracer", tracer_factory)
+
+    def fake_pytest_main(args=None):
+        return 1
+    monkeypatch.setattr(pytest, "main", fake_pytest_main)
+
+    exit_code = _run_cli(monkeypatch, ["oracletrace", "run", "--", "pytest"])
+
+    assert exit_code == 1
+
+


### PR DESCRIPTION
## Summary

Adds pytest integration through 
```sh
oracletrace run
```

## Related Issue

Closes #50 

## Type of Change

- [ ] Bug fix
- [X] New feature
- [X] Refactor
- [X] Documentation update
- [ ] CLI behavior change

## What Changed

- Adds the `oracle run` subcommand that allows to run oracletrace on pytrace execution
- Refactors the argument parser to support common arguments between `oracle trace <target.py>` and `oracletrace run ...`
- Updated documentation with this new subcommand 
- `top` argument validation returns `1` only in case of errors.

## Validation

- Added a new test for the pytest integration feature
- Ran the test suite

## Checklist

- [X] The code follows style conventions.
- [X] I added unit tests for the new functionality.
- [x] CI (GitHub Actions) is green.
- [X] I updated documentation/README when needed.


## Additional Notes

Error codes conventions do not really follow the same pattern as other tools, it might be something to look at in the future.
