### PR TITLE
fix: remove Python 3.10 classifier to match requires-python >=3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,9 @@ classifiers = [
     "Topic :: Software Development :: Testing",
     "Topic :: System :: Monitoring",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent"
 ]
 


### PR DESCRIPTION
## Summary

Removed the Python 3.10 classifier from `pyproject.toml` to align with the declared requirement `requires-python = ">=3.11"`.

## Related Issue

Closes #70

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] CLI behavior change

## What Changed

- Removed "Programming Language :: Python :: 3.10" classifier
- Added "Programming Language :: Python :: 3.13" classifier to reflect supported versions

## Validation

Verified that the classifiers now match `requires-python = ">=3.11"` and no longer indicate support for Python 3.10.

## Checklist

- [x] The code follows style conventions.
- [x] CI (GitHub Actions) is green.
- [ ] I added unit tests for the new functionality.
- [ ] I updated documentation/README when needed.

## Additional Notes

This change ensures consistency between supported Python versions and avoids misleading users about compatibility.
