### PR TITLE
Validate --repeat CLI values

### DIFF
--- a/oracletrace/cli.py
+++ b/oracletrace/cli.py
@@ -39,6 +39,17 @@ def _validate_top(top_str: Optional[str]) -> Tuple[Optional[int], Optional[int]]
     return top, None
 
 
+def _validate_repeat(repeat_str: Any) -> Tuple[int, Optional[int]]:
+    try:
+        repeat = int(repeat_str)
+        if repeat < 1:
+            raise ValueError
+    except ValueError:
+        print(f"argument --repeat: invalid int value: '{repeat_str}'", file=sys.stderr)
+        return 0, 1
+    return repeat, None
+
+
 def _compile_ignore_patterns(
     patterns: Optional[List[str]],
 ) -> Tuple[Optional[List[Pattern]], Optional[int]]:
@@ -200,6 +211,11 @@ def _run_target() -> int:
         return err
     args.top = top
 
+    repeat, err = _validate_repeat(args.repeat)
+    if err is not None:
+        return err
+    args.repeat = repeat
+
     ignore_patterns, err = _compile_ignore_patterns(args.ignore)
     if err is not None:
         return err
@@ -224,7 +240,7 @@ def _run_target() -> int:
             _tracer.stop()
         return _tracer, _tracer.get_trace_data()
 
-    runs: int = int(args.repeat)
+    runs: int = args.repeat
 
     if runs > 1:
         aggs: Dict[str, FunctionAggregate] = {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -324,6 +324,39 @@ def test_main_accepts_large_top_value(monkeypatch, tmp_path, trace_data):
     assert fake_tracer.show_results_calls == [99999]
 
 
+def test_main_rejects_zero_repeat(monkeypatch, tmp_path, capsys):
+    target = tmp_path / "target.py"
+    target.write_text("print('hello')\n", encoding="utf-8")
+
+    exit_code = _run_cli(monkeypatch, ["oracletrace", str(target), "--repeat", "0"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "argument --repeat: invalid int value" in captured.err
+
+
+def test_main_rejects_negative_repeat(monkeypatch, tmp_path, capsys):
+    target = tmp_path / "target.py"
+    target.write_text("print('hello')\n", encoding="utf-8")
+
+    exit_code = _run_cli(monkeypatch, ["oracletrace", str(target), "--repeat", "-1"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "argument --repeat: invalid int value" in captured.err
+
+
+def test_main_rejects_non_integer_repeat(monkeypatch, tmp_path, capsys):
+    target = tmp_path / "target.py"
+    target.write_text("print('hello')\n", encoding="utf-8")
+
+    exit_code = _run_cli(monkeypatch, ["oracletrace", str(target), "--repeat", "abc"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "argument --repeat: invalid int value" in captured.err
+
+
 def test_main_returns_1_when_compare_file_not_found(monkeypatch, tmp_path, trace_data, capsys):
     target = tmp_path / "target.py"
     target.write_text("print('hello')\n", encoding="utf-8")


### PR DESCRIPTION
﻿Fixes #65.

This validates `--repeat` before the target script is touched, using the same style as the existing `--top` validation. Invalid values now return a clear stderr message with exit code 1 instead of raising from `int(...)` or treating zero/negative values as a single run.

I added regression coverage for `--repeat 0`, `--repeat -1`, and `--repeat abc`.

Checked locally:
- `python -m pytest tests/test_cli.py --basetemp .pytest_tmp`
- `python -m mypy oracletrace`
- `python -m pytest -k "not test_symlinked_user_code" --basetemp .pytest_tmp`

The full suite has one Windows-local blocker unrelated to this change: `test_symlinked_user_code` needs permission to create symlinks and fails with WinError 1314 on this machine.
