### PR TITLE
docs: fix --ignore syntax in docs and templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -51,7 +51,7 @@ oracletrace your_script.py --json current.json --compare baseline.json
 
 ```bash
 oracletrace your_script.py --csv trace.csv
-oracletrace your_script.py --ignore "helper_function,debug_*"
+oracletrace your_script.py --ignore ".*helper_function.*" "debug_.*"
 oracletrace your_script.py --top 10
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ oracletrace your_script.py --json current.json --compare baseline.json
 
 ```bash
 oracletrace your_script.py --csv trace.csv
-oracletrace your_script.py --ignore "helper_function,debug_*"
+oracletrace your_script.py --ignore ".*helper_function.*" "debug_.*"
 oracletrace your_script.py --top 10
 ```
 


### PR DESCRIPTION
## Summary

Updates incorrect documentation of the `--ignore` cli flag

## Related Issue

Closes #69 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Documentation update
- [ ] CLI behavior change

## What Changed

- Fixed incorrect `--ignore` syntax in markdown files

## Validation

Describe how you validated this change.

- Verified all docs and templates files show the correct syntax.

## Checklist

- [ ] The code follows style conventions.
- [ ] I added unit tests for the new functionality.
- [X] CI (GitHub Actions) is green.
- [ ] I updated documentation/README when needed.
